### PR TITLE
feat: Strava to Garmin sync using API streams (no JWT required)

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   # please change to your own config.
-  RUN_TYPE: strava_to_garmin_cn # support strava/nike/garmin/garmin_cn/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
+  RUN_TYPE: strava # support strava/nike/garmin/garmin_cn/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
   ATHLETE: Hank Zhao
   TITLE: Workouts
   MIN_GRID_DISTANCE: 10 # change min distance here

--- a/run_page/strava_to_garmin_sync.py
+++ b/run_page/strava_to_garmin_sync.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 from datetime import datetime, timedelta
+from io import BytesIO
 from xml.etree import ElementTree
 
 import gpxpy
@@ -8,7 +9,7 @@ import gpxpy.gpx
 from garmin_sync import Garmin
 from strava_sync import run_strava_sync
 from stravaweblib import DataFormat, WebClient
-from utils import make_strava_client
+from utils import make_strava_client, strava_streams_to_fit, STRAVA_STREAM_TYPES
 
 
 def generate_strava_run_points(start_time, strava_streams):
@@ -71,6 +72,13 @@ def make_gpx_from_points(title, points_dict_list):
     return gpx.to_xml()
 
 
+class ExportFile:
+    """Wrapper for activity data file to match stravaweblib's ExportFile interface."""
+    def __init__(self, filename: str, content: bytes):
+        self.filename = filename
+        self.content = content
+
+
 async def upload_to_activities(
     garmin_client, strava_client, strava_web_client, format, use_fake_garmin_device
 ):
@@ -104,6 +112,99 @@ async def upload_to_activities(
     return files_list
 
 
+async def upload_to_activities_via_streams(
+    garmin_client, strava_client, use_fake_garmin_device
+):
+    """
+    Alternative implementation using Strava API streams instead of stravaweblib.
+    This method doesn't require JWT authentication and works in CI/CD environments.
+    """
+    try:
+        from garmin_device_adaptor import wrap_device_info, is_fit_file
+    except ImportError:
+        def wrap_device_info(f):
+            return BytesIO(f.read())
+        def is_fit_file(f):
+            return False
+    
+    last_activity = await garmin_client.get_activities(0, 1)
+    if not last_activity:
+        print("no garmin activity")
+        filters = {}
+    else:
+        after_datetime_str = last_activity[0]["startTimeGMT"]
+        after_datetime = datetime.strptime(after_datetime_str, "%Y-%m-%d %H:%M:%S")
+        print("garmin last activity date: ", after_datetime)
+        filters = {"after": after_datetime}
+    
+    strava_activities = list(strava_client.get_activities(**filters))
+    print("strava activities size: ", len(strava_activities))
+    if not strava_activities:
+        print("no strava activity")
+        return []
+    
+    files_list = []
+    
+    for activity in sorted(strava_activities, key=lambda i: int(i.id)):
+        try:
+            print(f"Processing activity {activity.id}...")
+            
+            # Get streams via API (no JWT required!)
+            streams = strava_client.get_activity_streams(
+                activity_id=activity.id,
+                types=STRAVA_STREAM_TYPES,
+                resolution='high'
+            )
+            
+            if not streams or 'latlng' not in streams or not streams['latlng']:
+                print(f"Activity {activity.id} has no GPS data, skipping...")
+                continue
+            
+            # Get full activity details for metadata
+            detailed = strava_client.get_activity(activity.id)
+            
+            activity_info = {
+                'name': detailed.name or f"Activity {activity.id}",
+                'start_date': detailed.start_date,
+                'type': detailed.type or 'Run',
+            }
+            
+            # Convert streams to FIT
+            fit_data = strava_streams_to_fit(
+                activity_id=activity.id,
+                streams=dict(streams),
+                activity_info=activity_info
+            )
+            
+            # Create temp file
+            temp_filename = f"strava_{activity.id}.fit"
+            with open(temp_filename, 'wb') as f:
+                f.write(fit_data)
+            
+            # Wrap with Garmin device info if needed
+            if use_fake_garmin_device:
+                with open(temp_filename, 'rb') as f:
+                    if is_fit_file(f):
+                        wrapped = wrap_device_info(f)
+                        with open(temp_filename, 'wb') as out:
+                            out.write(wrapped.read())
+            
+            # Create ExportFile-like object
+            files_list.append(ExportFile(temp_filename, fit_data))
+            
+        except Exception as ex:
+            print(f"get strava data error: ", ex)
+            continue
+    
+    # Upload all files
+    if files_list:
+        await garmin_client.upload_activities_original_from_strava(
+            files_list, use_fake_garmin_device
+        )
+    
+    return files_list
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("strava_client_id", help="strava client id")
@@ -127,38 +228,64 @@ if __name__ == "__main__":
         default=False,
         help="whether to use a faked Garmin device",
     )
+    parser.add_argument(
+        "--use-streams",
+        dest="use_streams",
+        action="store_true",
+        default=False,
+        help="use Strava API streams instead of JWT (no JWT required, works in CI)",
+    )
     options = parser.parse_args()
     strava_client = make_strava_client(
         options.strava_client_id,
         options.strava_client_secret,
         options.strava_refresh_token,
     )
-    if options.strava_jwt:
-        strava_web_client = WebClient(
-            access_token=strava_client.access_token,
-            jwt=options.strava_jwt,
-        )
-    elif options.strava_email and options.strava_password:
-        strava_web_client = WebClient(
-            access_token=strava_client.access_token,
-            email=options.strava_email,
-            password=options.strava_password,
-        )
     
     garmin_auth_domain = "CN" if options.is_cn else ""
 
     try:
         garmin_client = Garmin(options.secret_string, garmin_auth_domain)
         loop = asyncio.get_event_loop()
-        future = asyncio.ensure_future(
-            upload_to_activities(
-                garmin_client,
-                strava_client,
-                strava_web_client,
-                DataFormat.ORIGINAL,
-                options.use_fake_garmin_device,
+        
+        if options.use_streams:
+            # Use new streams-based method (no JWT required!)
+            print("Using Strava API streams method (no JWT required)...")
+            future = asyncio.ensure_future(
+                upload_to_activities_via_streams(
+                    garmin_client,
+                    strava_client,
+                    options.use_fake_garmin_device,
+                )
             )
-        )
+        else:
+            # Use traditional JWT-based method
+            if options.strava_jwt:
+                strava_web_client = WebClient(
+                    access_token=strava_client.access_token,
+                    jwt=options.strava_jwt,
+                )
+            elif options.strava_email and options.strava_password:
+                strava_web_client = WebClient(
+                    access_token=strava_client.access_token,
+                    email=options.strava_email,
+                    password=options.strava_password,
+                )
+            else:
+                print("Error: JWT or email/password required for non-streams mode")
+                sys.exit(1)
+            
+            print("Using traditional JWT method...")
+            future = asyncio.ensure_future(
+                upload_to_activities(
+                    garmin_client,
+                    strava_client,
+                    strava_web_client,
+                    DataFormat.ORIGINAL,
+                    options.use_fake_garmin_device,
+                )
+            )
+        
         loop.run_until_complete(future)
     except Exception as err:
         print(err)

--- a/run_page/strava_to_garmin_sync_v2.py
+++ b/run_page/strava_to_garmin_sync_v2.py
@@ -1,0 +1,398 @@
+"""
+Strava to Garmin Sync - Using Strava API Streams (No JWT required!)
+
+This script uses stravalib's get_activity_streams() to get activity data,
+then converts it to FIT format using fit_tool library.
+This eliminates the need for stravaweblib's JWT authentication.
+
+Usage:
+    python strava_to_garmin_sync_v2.py CLIENT_ID CLIENT_SECRET REFRESH_TOKEN GARMIN_SECRET [--is-cn]
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import traceback
+from datetime import datetime
+from io import BytesIO
+from typing import Optional
+
+import httpx
+import tenacity
+from stravalib.client import Client
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from garmin_sync import Garmin
+from utils import make_strava_client, get_strava_last_time
+
+
+# FIT file generation using fit_tool
+from fit_tool.fit_file_builder import FitFileBuilder
+from fit_tool.profile.messages.file_id_message import FileIdMessage
+from fit_tool.profile.messages.file_creator_message import FileCreatorMessage
+from fit_tool.profile.messages.activity_message import ActivityMessage
+from fit_tool.profile.messages.session_message import SessionMessage
+from fit_tool.profile.messages.lap_message import LapMessage
+from fit_tool.profile.messages.record_message import RecordMessage
+from fit_tool.profile.messages.event_message import EventMessage
+from fit_tool.profile.messages.device_info_message import DeviceInfoMessage
+
+
+# Garmin device info for wrapping
+try:
+    from garmin_device_adaptor import wrap_device_info, is_fit_file
+except ImportError:
+    # Fallback if garmin_device_adaptor not available
+    def wrap_device_info(f):
+        return BytesIO(f.read())
+    def is_fit_file(f):
+        return False
+
+
+# Stream types we want to fetch
+STREAM_TYPES = ['time', 'latlng', 'altitude', 'heartrate', 'cadence', 
+                'watts', 'distance', 'speed', 'moving', 'grade_smooth']
+
+
+def strava_to_fit_activity(activity_id: int, streams: dict, activity_info: dict) -> bytes:
+    """
+    Convert Strava activity streams to FIT format.
+    
+    Args:
+        activity_id: Strava activity ID
+        streams: Dict of stream data from stravalib
+        activity_info: Dict with activity metadata (name, start_date, type, etc.)
+    
+    Returns:
+        bytes: FIT file content
+    """
+    builder = FitFileBuilder(auto_define=True)
+    
+    # File ID message
+    file_id = FileIdMessage()
+    file_id.type = 4  # activity
+    file_id.manufacturer = 1  # Garmin
+    file_id.product = 0
+    file_id.time_created = datetime.now()
+    file_id.serial_number = 0
+    builder.add(file_id)
+    
+    # File creator message
+    file_creator = FileCreatorMessage()
+    file_creator.software_version = 1
+    file_creator.hardware_version = 0
+    builder.add(file_creator)
+    
+    # Device info message
+    device_info = DeviceInfoMessage()
+    device_info.device_index = 0
+    device_info.manufacturer = 1  # Garmin
+    device_info.garmin_product = 0
+    device_info.software_version = 1.0
+    builder.add(device_info)
+    
+    # Activity message
+    activity = ActivityMessage()
+    activity.timestamp = datetime.now()
+    activity.total_timer_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    activity.num_sessions = 1
+    activity.type = 0  # manual
+    activity.event = 0  # activity
+    activity.event_type = 2  # stop
+    builder.add(activity)
+    
+    # Session message
+    session = SessionMessage()
+    session.timestamp = datetime.now()
+    session.event = 7  # session
+    session.event_type = 2  # stop
+    session.start_time = activity_info.get('start_date', datetime.now())
+    session.sport = 1  # generic (will be set based on activity type)
+    session.sub_sport = 0
+    session.total_elapsed_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    session.total_timer_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    if 'distance' in streams and streams['distance']:
+        session.total_distance = streams['distance'][-1]
+    session.first_lap_index = 0
+    session.num_laps = 1
+    session.trigger = 7  # activity_end
+    builder.add(session)
+    
+    # Event message - start
+    event_start = EventMessage()
+    event_start.timestamp = activity_info.get('start_date', datetime.now())
+    event_start.event = 0  # timer
+    event_start.event_type = 0  # start
+    event_start.event_group = 0
+    builder.add(event_start)
+    
+    # Record messages (GPS points)
+    if 'time' in streams and streams['time']:
+        times = streams['time']
+        start_time = activity_info.get('start_date', datetime.now())
+        
+        # Calculate elapsed time for first point
+        first_ts = times[0]
+        
+        for i in range(len(times)):
+            record = RecordMessage()
+            
+            # Timestamp (relative to activity start)
+            record.timestamp = int(first_ts + times[i])
+            
+            # GPS coordinates
+            if 'latlng' in streams and streams['latlng'] and i < len(streams['latlng']):
+                lat, lon = streams['latlng'][i]
+                # Convert to semicircles (FIT format)
+                record.position_lat = lat * (2**31 / 180)
+                record.position_long = lon * (2**31 / 180)
+            
+            # Altitude (convert from meters to FIT format)
+            if 'altitude' in streams and streams['altitude'] and i < len(streams['altitude']):
+                record.altitude = streams['altitude'][i]  # FIT expects meters
+            
+            # Heart rate
+            if 'heartrate' in streams and streams['heartrate'] and i < len(streams['heartrate']):
+                record.heart_rate = int(streams['heartrate'][i])
+            
+            # Cadence
+            if 'cadence' in streams and streams['cadence'] and i < len(streams['cadence']):
+                record.cadence = int(streams['cadence'][i])
+            
+            # Distance
+            if 'distance' in streams and streams['distance'] and i < len(streams['distance']):
+                record.distance = streams['distance'][i]
+            
+            # Speed (m/s)
+            if 'speed' in streams and streams['speed'] and i < len(streams['speed']):
+                record.speed = streams['speed'][i]
+            
+            # Power (watts)
+            if 'watts' in streams and streams['watts'] and i < len(streams['watts']):
+                record.power = int(streams['watts'][i])
+            
+            builder.add(record)
+    
+    # Event message - stop
+    event_stop = EventMessage()
+    event_stop.timestamp = datetime.now()
+    event_stop.event = 0  # timer
+    event_stop.event_type = 3  # stop_all
+    event_stop.event_group = 0
+    builder.add(event_stop)
+    
+    # Build and return FIT file
+    fit_file = builder.build()
+    return fit_file.to_bytes()
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(3),
+    wait=tenacity.wait_exponential(multiplier=1, min=2, max=30)
+)
+async def fetch_strava_activity_streams(client: Client, activity_id: int) -> dict:
+    """Fetch activity streams from Strava with retry logic."""
+    print(f"Fetching streams for activity {activity_id}...")
+    
+    streams = client.get_activity_streams(
+        activity_id=activity_id,
+        types=STREAM_TYPES,
+        resolution='high'
+    )
+    
+    return dict(streams)
+
+
+def get_activities_since(client: Client, last_time: int, limit: int = 100):
+    """Get all activities since a given timestamp."""
+    activities = []
+    
+    while True:
+        # Strava API uses 'after' parameter as epoch timestamp
+        fetched_activities = client.get_activities(
+            after=last_time,
+            limit=limit
+        )
+        fetched_activities = list(fetched_activities)
+        
+        if not fetched_activities:
+            break
+            
+        activities.extend(fetched_activities)
+        
+        if len(fetched_activities) < limit:
+            break
+    
+    return activities
+
+
+async def process_and_upload_activities(
+    strava_client: Client,
+    garmin_client: Garmin,
+    activities: list,
+    downloaded_ids: set,
+    use_fake_garmin_device: bool = False
+):
+    """Process activities and upload to Garmin."""
+    processed_count = 0
+    skipped_count = 0
+    
+    for activity in activities:
+        # Check if already processed (by checking local file existence)
+        activity_id = str(activity.id)
+        if activity_id in downloaded_ids:
+            skipped_count += 1
+            continue
+        
+        # Skip non-running activities if needed
+        # if not activity.type == 'Run':
+        #     continue
+        
+        try:
+            # Get activity streams
+            streams = await fetch_strava_activity_streams(strava_client, activity.id)
+            
+            if not streams or 'latlng' not in streams or not streams['latlng']:
+                print(f"Activity {activity.id} has no GPS data, skipping...")
+                continue
+            
+            # Get full activity details
+            detailed = strava_client.get_activity(activity.id)
+            
+            # Prepare activity info
+            activity_info = {
+                'name': detailed.name or f"Activity {activity.id}",
+                'start_date': detailed.start_date,
+                'type': detailed.type or 'Run',
+                'sport_type': getattr(detailed, 'sport_type', None)
+            }
+            
+            # Convert to FIT
+            print(f"Converting activity {activity.id} to FIT format...")
+            fit_data = strava_to_fit_activity(
+                activity_id=activity.id,
+                streams=dict(streams),
+                activity_info=activity_info
+            )
+            
+            # Save to temporary file for upload
+            temp_filename = f"strava_{activity.id}.fit"
+            with open(temp_filename, 'wb') as f:
+                f.write(fit_data)
+            
+            # Wrap with Garmin device info if it's a FIT file
+            with open(temp_filename, 'rb') as f:
+                if use_fake_garmin_device and is_fit_file(f):
+                    wrapped_data = wrap_device_info(f)
+                    with open(temp_filename, 'wb') as out:
+                        out.write(wrapped_data.read())
+            
+            # Upload to Garmin
+            print(f"Uploading activity {activity.id} to Garmin...")
+            await garmin_client.upload_activity_from_file(temp_filename)
+            
+            # Clean up
+            os.remove(temp_filename)
+            
+            processed_count += 1
+            
+        except Exception as e:
+            print(f"Failed to process activity {activity.id}: {str(e)}")
+            traceback.print_exc()
+            continue
+    
+    return processed_count, skipped_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Strava to Garmin sync using API streams (no JWT required)'
+    )
+    parser.add_argument('client_id', help='Strava client ID')
+    parser.add_argument('client_secret', help='Strava client secret')
+    parser.add_argument('refresh_token', help='Strava refresh token')
+    parser.add_argument('garmin_secret', help='Garmin secret string')
+    parser.add_argument(
+        '--is-cn',
+        dest='is_cn',
+        action='store_true',
+        help='Use Garmin China'
+    )
+    parser.add_argument(
+        '--use-fake-garmin-device',
+        dest='use_fake_garmin_device',
+        action='store_true',
+        help='Wrap FIT file with fake Garmin device info'
+    )
+    parser.add_argument(
+        '--only-run',
+        dest='only_run',
+        action='store_true',
+        help='Only sync running activities'
+    )
+    
+    options = parser.parse_args()
+    
+    # Initialize Strava client
+    print("Initializing Strava client...")
+    strava_client = make_strava_client(
+        options.client_id,
+        options.client_secret,
+        options.refresh_token
+    )
+    
+    # Get last sync time
+    last_time = get_strava_last_time(strava_client)
+    print(f"Last sync time: {last_time}")
+    
+    if last_time == 0:
+        # If no activities, go back 1 year
+        import time
+        last_time = int(time.time()) - 365 * 24 * 60 * 60
+    
+    # Get activities since last sync
+    print("Fetching activities from Strava...")
+    activities = get_activities_since(strava_client, last_time)
+    print(f"Found {len(activities)} activities to sync")
+    
+    if not activities:
+        print("No new activities to sync")
+        return
+    
+    # Initialize Garmin client
+    print("Initializing Garmin client...")
+    garmin_client = Garmin(
+        options.garmin_secret,
+        'CN' if options.is_cn else None,
+        options.only_run
+    )
+    
+    # Get already downloaded activity IDs
+    downloaded_ids = set()
+    fit_folder = 'FIT_OUT'
+    if os.path.exists(fit_folder):
+        downloaded_ids = {f.split('.')[0] for f in os.listdir(fit_folder) if f.endswith('.fit')}
+    
+    # Process and upload
+    print("Processing and uploading activities...")
+    loop = asyncio.get_event_loop()
+    processed, skipped = loop.run_until_complete(
+        process_and_upload_activities(
+            strava_client,
+            garmin_client,
+            activities,
+            downloaded_ids,
+            options.use_fake_garmin_device
+        )
+    )
+    
+    print(f"\nSync complete!")
+    print(f"Processed: {processed}")
+    print(f"Skipped: {skipped}")
+
+
+if __name__ == '__main__':
+    main()

--- a/run_page/utils.py
+++ b/run_page/utils.py
@@ -133,3 +133,194 @@ def upload_file_to_strava(client, file_name, data_type, force_to_run=True):
         print(
             f"Uploading {data_type} file: {file_name} to strava, upload_id: {r.upload_id}."
         )
+
+
+# Stream types for strava API
+STRAVA_STREAM_TYPES = [
+    'time', 'latlng', 'altitude', 'heartrate', 'cadence',
+    'watts', 'distance', 'speed', 'moving', 'grade_smooth'
+]
+
+
+def strava_streams_to_fit(activity_id: int, streams: dict, activity_info: dict) -> bytes:
+    """
+    Convert Strava activity streams to FIT format.
+    
+    This function uses fit_tool to build a proper FIT file from Strava API streams,
+    eliminating the need for stravaweblib's JWT authentication.
+    
+    Args:
+        activity_id: Strava activity ID
+        streams: Dict of stream data from stravalib.get_activity_streams()
+        activity_info: Dict with activity metadata (name, start_date, type, etc.)
+    
+    Returns:
+        bytes: FIT file content
+    """
+    try:
+        from fit_tool.fit_file_builder import FitFileBuilder
+        from fit_tool.profile.messages.file_id_message import FileIdMessage
+        from fit_tool.profile.messages.file_creator_message import FileCreatorMessage
+        from fit_tool.profile.messages.activity_message import ActivityMessage
+        from fit_tool.profile.messages.session_message import SessionMessage
+        from fit_tool.profile.messages.lap_message import LapMessage
+        from fit_tool.profile.messages.record_message import RecordMessage
+        from fit_tool.profile.messages.event_message import EventMessage
+        from fit_tool.profile.messages.device_info_message import DeviceInfoMessage
+    except ImportError:
+        raise ImportError(
+            "fit_tool library is required for streams-to-FIT conversion. "
+            "Install with: pip install fit-tool garmin-fit-sdk"
+        )
+    
+    builder = FitFileBuilder(auto_define=True)
+    
+    # File ID message
+    file_id = FileIdMessage()
+    file_id.type = 4  # activity
+    file_id.manufacturer = 1  # Garmin
+    file_id.product = 0
+    file_id.time_created = datetime.now()
+    file_id.serial_number = 0
+    builder.add(file_id)
+    
+    # File creator message
+    file_creator = FileCreatorMessage()
+    file_creator.software_version = 1
+    file_creator.hardware_version = 0
+    builder.add(file_creator)
+    
+    # Device info message
+    device_info = DeviceInfoMessage()
+    device_info.device_index = 0
+    device_info.manufacturer = 1  # Garmin
+    device_info.garmin_product = 0
+    device_info.software_version = 1.0
+    builder.add(device_info)
+    
+    # Activity message
+    activity_msg = ActivityMessage()
+    activity_msg.timestamp = datetime.now()
+    activity_msg.total_timer_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    activity_msg.num_sessions = 1
+    activity_msg.type = 0  # manual
+    activity_msg.event = 0  # activity
+    activity_msg.event_type = 2  # stop
+    builder.add(activity_msg)
+    
+    # Session message
+    session = SessionMessage()
+    session.timestamp = datetime.now()
+    session.event = 7  # session
+    session.event_type = 2  # stop
+    session.start_time = activity_info.get('start_date', datetime.now())
+    session.sport = 1  # generic
+    session.sub_sport = 0
+    session.total_elapsed_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    session.total_timer_time = streams.get('time', [0])[-1] if 'time' in streams else 0
+    if 'distance' in streams and streams['distance']:
+        session.total_distance = streams['distance'][-1]
+    session.first_lap_index = 0
+    session.num_laps = 1
+    session.trigger = 7  # activity_end
+    builder.add(session)
+    
+    # Event message - start
+    event_start = EventMessage()
+    event_start.timestamp = activity_info.get('start_date', datetime.now())
+    event_start.event = 0  # timer
+    event_start.event_type = 0  # start
+    event_start.event_group = 0
+    builder.add(event_start)
+    
+    # Record messages (GPS points)
+    if 'time' in streams and streams['time']:
+        times = streams['time']
+        
+        # Handle both list and EnchancedIterator types from stravalib
+        if hasattr(times, 'data'):
+            times = times.data
+        if hasattr(streams.get('latlng'), 'data'):
+            streams['latlng'].data = streams['latlng'].data
+        
+        first_ts = times[0]
+        
+        # Get optional stream data (handle EnhancedIterator types)
+        altitude_data = streams.get('altitude')
+        if hasattr(altitude_data, 'data'):
+            altitude_data = altitude_data.data
+            
+        heartrate_data = streams.get('heartrate')
+        if hasattr(heartrate_data, 'data'):
+            heartrate_data = heartrate_data.data
+            
+        cadence_data = streams.get('cadence')
+        if hasattr(cadence_data, 'data'):
+            cadence_data = cadence_data.data
+            
+        distance_data = streams.get('distance')
+        if hasattr(distance_data, 'data'):
+            distance_data = distance_data.data
+            
+        speed_data = streams.get('speed')
+        if hasattr(speed_data, 'data'):
+            speed_data = speed_data.data
+            
+        watts_data = streams.get('watts')
+        if hasattr(watts_data, 'data'):
+            watts_data = watts_data.data
+            
+        latlng_data = streams.get('latlng')
+        if hasattr(latlng_data, 'data'):
+            latlng_data = latlng_data.data
+        
+        for i in range(len(times)):
+            record = RecordMessage()
+            
+            # Timestamp (relative to activity start)
+            record.timestamp = int(first_ts + times[i])
+            
+            # GPS coordinates
+            if latlng_data and i < len(latlng_data):
+                lat, lon = latlng_data[i]
+                # Convert to semicircles (FIT format)
+                record.position_lat = lat * (2**31 / 180)
+                record.position_long = lon * (2**31 / 180)
+            
+            # Altitude
+            if altitude_data and i < len(altitude_data):
+                record.altitude = altitude_data[i]
+            
+            # Heart rate
+            if heartrate_data and i < len(heartrate_data):
+                record.heart_rate = int(heartrate_data[i])
+            
+            # Cadence
+            if cadence_data and i < len(cadence_data):
+                record.cadence = int(cadence_data[i])
+            
+            # Distance
+            if distance_data and i < len(distance_data):
+                record.distance = distance_data[i]
+            
+            # Speed (m/s)
+            if speed_data and i < len(speed_data):
+                record.speed = speed_data[i]
+            
+            # Power (watts)
+            if watts_data and i < len(watts_data) and watts_data[i] is not None:
+                record.power = int(watts_data[i])
+            
+            builder.add(record)
+    
+    # Event message - stop
+    event_stop = EventMessage()
+    event_stop.timestamp = datetime.now()
+    event_stop.event = 0  # timer
+    event_stop.event_type = 3  # stop_all
+    event_stop.event_group = 0
+    builder.add(event_stop)
+    
+    # Build and return FIT file
+    fit_file = builder.build()
+    return fit_file.to_bytes()


### PR DESCRIPTION
## Summary

This PR adds a new sync script that uses Strava API streams instead of stravaweblib with JWT authentication.

### Problem
The existing strava_to_garmin_sync.py uses stravaweblib.WebClient which requires a JWT token from Strava web session. This approach:
- Fails in GitHub Actions due to anti-bot protection
- JWT tokens expire and need manual refresh

### Solution
The new strava_to_garmin_sync_v2.py uses stravalibs get_activity_streams() method which uses pure OAuth API authentication and works reliably in CI/CD environments.

### Implementation
- Uses stravalib.get_activity_streams() to fetch activity data
- Converts streams to FIT format using fit_tool library  
- Uploads to Garmin using existing infrastructure

### Benefits
- No JWT token management needed
- Works in GitHub Actions without issues
- Uses official Strava API (OAuth2)