### PR TITLE
feat: v3.0.0 — Habit Check-in Module & Global GitHub Auth

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -22,10 +22,6 @@ on:
 env:
   # please change to your own config.
   RUN_TYPE: strava # support strava/nike/garmin/garmin_cn/keep/only_gpx/only_fit/nike_to_strava/strava_to_garmin/strava_to_garmin_cn/garmin_to_strava/garmin_to_strava_cn/codoon, Please change the 'pass' it to your own
-  ATHLETE: Hank Zhao
-  TITLE: Workouts
-  MIN_GRID_DISTANCE: 10 # change min distance here
-  TITLE_GRID: Over 10km Workouts # also here
   GITHUB_NAME: zhaohongxuan  # change to yours
   GITHUB_EMAIL: hxzhenu@gmail.com # change to yours
 
@@ -42,10 +38,6 @@ jobs:
   sync:
     name: Sync
     runs-on: ubuntu-latest
-    outputs:
-      SAVE_DATA_IN_GITHUB_CACHE: ${{ steps.set_output.outputs.SAVE_DATA_IN_GITHUB_CACHE }}
-      DATA_CACHE_PREFIX: ${{ steps.set_output.outputs.DATA_CACHE_PREFIX }}
-      BUILD_GH_PAGES: ${{ steps.set_output.outputs.BUILD_GH_PAGES }}
 
     steps:
       - name: Checkout
@@ -168,14 +160,6 @@ jobs:
         run: |
           python run_page/tulipsport_sync.py ${{ secrets.TULIPSPORT_TOKEN }} --with-gpx
 
-      - name: Make svg GitHub profile
-        if: env.RUN_TYPE != 'pass'
-        run: |
-          python run_page/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python run_page/gen_svg.py --from-db --title "${{ env.TITLE_GRID }}" --type grid --athlete "${{ env.ATHLETE }}" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "${{ env.MIN_GRID_DISTANCE }}"
-          python run_page/gen_svg.py --from-db --type circular --use-localtime
-          python run_page/gen_svg.py --from-db --year $(date +"%Y")  --language zh_CN --title "$(date +"%Y") Workouts" --type github --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github_$(date +"%Y").svg --use-localtime --min-distance 0.5
-
       - name: Push new runs
         if: env.SAVE_DATA_IN_GITHUB_CACHE != 'true'
         run: |
@@ -185,19 +169,12 @@ jobs:
           git commit -m 'Add new workouts' || echo "nothing to commit"
           git push || echo "nothing to push"
 
-      - name: Set Output
-        id: set_output
-        run: |
-          echo "SAVE_DATA_IN_GITHUB_CACHE=${{ env.SAVE_DATA_IN_GITHUB_CACHE }}" >> "$GITHUB_OUTPUT"
-          echo "DATA_CACHE_PREFIX=${{ env.DATA_CACHE_PREFIX }}" >> "$GITHUB_OUTPUT"
-          echo "BUILD_GH_PAGES=${{ env.BUILD_GH_PAGES }}" >> "$GITHUB_OUTPUT"
-
   publish_github_pages:
-    if: needs.sync.result == 'success' && needs.sync.outputs.BUILD_GH_PAGES == 'true'
+    if: needs.sync.result == 'success' && vars.BUILD_GH_PAGES != 'false'
     name: Build and publish Github Pages
     uses: ./.github/workflows/gh-pages.yml
     with:
-      save_data_in_github_cache: ${{needs.sync.outputs.SAVE_DATA_IN_GITHUB_CACHE == 'true'}}
-      data_cache_prefix: ${{needs.sync.outputs.DATA_CACHE_PREFIX}}
+      save_data_in_github_cache: false
+      data_cache_prefix: 'track_data'
     needs:
       - sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [3.0.0] - 2026-05-18
+
+### Added
+- **Habit Check-in module** — new top-level "Habits" tab for daily pushups, squats and cold shower tracking
+  - One-tap check-in with auto-recorded timestamp
+  - Per-item default reps configurable via settings panel (saved to localStorage)
+  - Three independent heatmaps (pushups / squats / cold shower) with per-year navigation
+  - Check-in log grouped by date with precise time display
+  - Stats card: streak, total days, per-item days and total reps
+- **Global GitHub authentication** — PAT login via Header dropdown, shared across all features
+  - GitHub avatar displayed in top-right corner when signed in
+  - Logout from dropdown menu
+- **Strava sync trigger** — "Sync" button in Latest Activity card triggers `run_data_sync.yml` workflow dispatch
+  - Real-time status polling (queued → in_progress → success / failure)
+  - Clickable status badge links to GitHub Actions run
+- **iOS Shortcuts guide** (`docs/ios-shortcuts.md`) — three Shortcut templates for one-tap mobile check-in without opening the browser
+- **lucide-react** icon library added for consistent UI icons
+- Route icon added before total distance in profile card
+
+### Changed
+- Profile card avatar removed; GitHub avatar shown when authenticated, placeholder SVG otherwise
+- GitHub repo link moved from header to footer
+- Footer updated to include GitHub icon + link alongside copyright
+- Footprint Map (ChinaMap) height increased by 10px (180 → 190)
+- Workflow `run_data_sync.yml`: removed "Make svg GitHub profile" and "Set Output" steps; removed SVG-related env vars (`ATHLETE`, `TITLE`, `MIN_GRID_DISTANCE`, `TITLE_GRID`); simplified `publish_github_pages` job to use hardcoded values
+- `data/checkins.json` added as the persistent check-in data store (read/written via GitHub Contents API)
+
+### Removed
+- Local avatar image dependency from ProfileCard
+- Device Flow OAuth (replaced with simpler PAT input in header dropdown)
+
+---
+
+## [2.0.0] - 2024
+
+### Added
+- Full dashboard redesign with two-column layout
+- ContributionHeatmap with multi-year support and sport-type color palettes
+- TracksPage with Mapbox route visualization
+- ChinaMap footprint heatmap
+- PersonalBest component
+- CalendarWidget
+- Dark/light theme with CSS custom properties
+- i18n (zh/en) via Context
+- Config via `config.yml` (locale, theme, goals)
+- Gym mode with session tracking
+
+### Changed
+- Migrated from plain HTML/JS to React 18 + TypeScript + Vite
+- Tailwind CSS v4
+
+---
+
+## [1.0.0] - 2023
+
+### Added
+- Initial workout dashboard
+- Activity heatmap
+- Static activities.json data pipeline
+- GitHub Pages deployment

--- a/config.yml
+++ b/config.yml
@@ -44,3 +44,13 @@ goals:
     monthly: 600   # 10 小时
     weekly: 150    # 2.5 小时
     unit: time
+
+# ── 打卡模块 ──────────────────────────────────────────────────────────────────
+# GitHub OAuth App 的 Client ID（Device Flow 不需要 client_secret，client_id 可公开）
+# 注册地址：https://github.com/settings/applications/new
+# Authorization callback URL 填写你的站点域名即可（Device Flow 不实际使用 callback）
+githubClientId: 'Ov23liIA4gcZ3hXZkJnP'
+
+# 打卡数据存储位置（当前 repo），格式：username/repo-name
+repoOwner: 'zhaohongxuan'
+repoName: 'workouts'

--- a/docs/ios-shortcuts.md
+++ b/docs/ios-shortcuts.md
@@ -1,0 +1,179 @@
+# iOS 快捷指令打卡方案
+
+不需要打开网页，直接从 iPhone 主屏或小组件一键完成打卡。
+
+---
+
+## 前置准备
+
+### 1. 创建 GitHub Personal Access Token (PAT)
+
+1. 打开 [https://github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta)（Fine-grained tokens）
+2. 点击 **Generate new token**
+3. Token name：`checkin-shortcut`
+4. Expiration：选择你喜欢的过期时间（建议 1 年）
+5. Repository access：选择 **Only select repositories** → 选你的 workouts repo
+6. Permissions → **Contents**：选 `Read and write`
+7. 点击 **Generate token** → 复制保存好 token（只显示一次！）
+
+---
+
+## 快捷指令方案
+
+### 方案 A：一键全部打卡（最简单）
+
+点击后直接把今天三项全部打卡为完成。
+
+**手动创建步骤：**
+
+1. 打开 iPhone「快捷指令」App → 点击右上角 `+`
+2. 添加动作 **「文本」**，内容填：
+   ```
+   YOUR_GITHUB_TOKEN
+   ```
+   （替换为你的 PAT）
+
+3. 添加动作 **「脚本」→「运行 JavaScript」**，代码如下：
+
+```javascript
+const token = inputText // 从上一步「文本」传入
+
+const owner = 'YOUR_USERNAME'    // 替换为你的 GitHub 用户名
+const repo = 'YOUR_REPO_NAME'    // 替换为你的 repo 名，如 workouts
+const path = 'data/checkins.json'
+
+const today = new Date().toLocaleDateString('sv-SE', {
+  timeZone: 'Asia/Shanghai'  // 替换为你的时区
+})
+
+const headers = {
+  'Authorization': `Bearer ${token}`,
+  'Accept': 'application/vnd.github+json',
+  'Content-Type': 'application/json'
+}
+
+// 读取当前文件
+const getRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, { headers })
+const getData = await getRes.json()
+const sha = getData.sha
+const current = JSON.parse(atob(getData.content.replace(/\n/g, '')))
+
+// 更新今日打卡
+const existing = current.checkins.find(c => c.date === today)
+if (existing) {
+  existing.pushups = true
+  existing.squats = true
+  existing.coldShower = true
+} else {
+  current.checkins.push({ date: today, pushups: true, squats: true, coldShower: true })
+  current.checkins.sort((a, b) => a.date.localeCompare(b.date))
+}
+
+// 写回文件
+const newContent = btoa(unescape(encodeURIComponent(JSON.stringify(current, null, 2) + '\n')))
+await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+  method: 'PUT',
+  headers,
+  body: JSON.stringify({
+    message: `checkin: ${today} all done`,
+    content: newContent,
+    sha
+  })
+})
+
+return `✅ ${today} 打卡成功！`
+```
+
+4. 添加动作 **「通知」**，显示「运行 JavaScript」的结果
+5. 保存快捷指令，命名为「每日打卡」，设置一个好看的图标
+
+---
+
+### 方案 B：选择打卡（灵活）
+
+运行时弹出菜单，选择今天完成了哪几项。
+
+**关键差异**（在方案 A 基础上修改）：
+
+在「运行 JavaScript」前，添加：
+
+1. **「脚本」→「从菜单中选取」**
+   - 提示：`今天完成了哪些？`
+   - 选项：
+     - `💪 俯卧撑`
+     - `🏋️ 深蹲`
+     - `🚿 冷水澡`
+     - `💪🏋️🚿 全部完成`
+
+2. 用「如果」判断各选项，设置对应变量
+
+或者更简单地，使用 **「询问输入」** 动作，每次询问三个是/否问题。
+
+---
+
+### 方案 C：自动化触发（每天早晨提醒）
+
+1. 打开「快捷指令」→ 切换到「自动化」标签页
+2. 点击 `+` → **「个人自动化」**
+3. 选择 **「一天中的时间」** → 设为 `08:00`
+4. 动作：**「运行快捷指令」** → 选择上面的「每日打卡」
+5. 关闭「运行前询问」（可选，这样完全静默运行）
+
+---
+
+## 通过 API 直接打卡（高级用户）
+
+如果你熟悉命令行，也可以用 curl：
+
+```bash
+#!/bin/bash
+OWNER="YOUR_USERNAME"
+REPO="YOUR_REPO_NAME"
+TOKEN="YOUR_TOKEN"
+TODAY=$(date +%Y-%m-%d)
+
+# 读取当前文件
+RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/contents/data/checkins.json")
+
+SHA=$(echo $RESPONSE | python3 -c "import json,sys; print(json.load(sys.stdin)['sha'])")
+CONTENT=$(echo $RESPONSE | python3 -c "import json,sys,base64; \
+  d=json.load(sys.stdin); \
+  print(base64.b64decode(d['content']).decode())")
+
+# 更新内容（Python 脚本）
+NEW_CONTENT=$(python3 << EOF
+import json, base64
+
+data = json.loads('''$CONTENT''')
+today = "$TODAY"
+
+existing = next((c for c in data['checkins'] if c['date'] == today), None)
+if existing:
+    existing.update({'pushups': True, 'squats': True, 'coldShower': True})
+else:
+    data['checkins'].append({'date': today, 'pushups': True, 'squats': True, 'coldShower': True})
+    data['checkins'].sort(key=lambda x: x['date'])
+
+print(base64.b64encode(json.dumps(data, indent=2).encode()).decode())
+EOF
+)
+
+# 提交
+curl -s -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.github.com/repos/$OWNER/$REPO/contents/data/checkins.json" \
+  -d "{\"message\": \"checkin: $TODAY\", \"content\": \"$NEW_CONTENT\", \"sha\": \"$SHA\"}"
+
+echo "✅ $TODAY 打卡完成"
+```
+
+---
+
+## 注意事项
+
+- **时区**：JavaScript 中 `new Date()` 使用设备时区，一般没问题。如果你在境外，注意调整
+- **并发冲突**：如果网页端和快捷指令同时打卡，可能出现 `sha` 冲突（409 错误）。此时重试即可
+- **Token 安全**：PAT 存在快捷指令的「文本」动作中，不会同步到 iCloud（快捷指令默认不加密）。建议使用权限最小的 Fine-grained token，只给目标 repo 的 Contents 读写权限
+- **GitHub Actions**：每次打卡都会产生一个 commit，如果你有自动 CI/CD，注意是否会触发不必要的构建（可以在 commit message 中加 `[skip ci]`）

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workout-dashboard",
   "description": "Modern workout dashboard with contribution heatmap",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Hank Zhao<hxzhenu@gmail.com>",
   "license": "MIT",
   "private": true,
@@ -20,6 +20,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.2.1",
     "html2canvas": "^1.4.1",
+    "lucide-react": "^1.16.0",
     "mapbox-gl": "^3.23.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       html2canvas:
         specifier: ^1.4.1
         version: 1.4.1
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@18.3.1)
       mapbox-gl:
         specifier: ^3.23.1
         version: 3.23.1
@@ -1098,6 +1101,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2319,6 +2327,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@1.16.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-string@0.30.21:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import type { Activity, SportFilter } from './types'
 import { useFilteredActivities, getAvailableYears, extractProvince } from './hooks/useActivities'
 import { useTheme } from './hooks/useTheme'
 import { LocaleProvider } from './hooks/useLocale'
+import { GitHubAuthProvider } from './hooks/useGitHubAuthContext'
 import { Header } from './components/Header'
 import { StatsCards } from './components/StatsCards'
 import { ContributionHeatmap } from './components/ContributionHeatmap'
@@ -14,11 +15,12 @@ import { ProfileCard } from './components/ProfileCard'
 import { PersonalBest } from './components/PersonalBest'
 import { TracksPage } from './components/TracksPage'
 import { ChinaMap } from './components/ChinaMap'
+import { CheckinPage } from './components/CheckinPage'
 import rawActivities from './static/activities.json'
 
 const activities = rawActivities as Activity[]
 
-type Page = 'home' | 'tracks'
+type Page = 'home' | 'tracks' | 'checkin'
 
 export default function App() {
   const { dark, toggle } = useTheme()
@@ -40,7 +42,8 @@ export default function App() {
 
   return (
     <LocaleProvider>
-      <div className="min-h-screen bg-[var(--color-bg)]" data-filter={filter}>
+      <GitHubAuthProvider>
+        <div className="min-h-screen bg-[var(--color-bg)]" data-filter={filter}>
       <Header
         filter={filter}
         setFilter={setFilter}
@@ -58,6 +61,8 @@ export default function App() {
           onSelectActivity={setSelectedActivity}
           onBack={() => setPage('home')}
         />
+      ) : page === 'checkin' ? (
+        <CheckinPage />
       ) : (
       <main className="max-w-[1400px] mx-auto px-6 py-6">
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_380px] gap-6 items-start">
@@ -105,9 +110,23 @@ export default function App() {
       )}
 
       <footer className="text-center py-6 text-sm text-[var(--color-muted)] border-t border-[var(--color-border)]">
-        &copy; {new Date().getFullYear()} Workout Dashboard. 
-      </footer>
-      </div>
+          <div className="flex items-center justify-center gap-3">
+            <span>&copy; {new Date().getFullYear()} Workout Dashboard.</span>
+            <a
+              href="https://github.com/zhaohongxuan/workouts"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 hover:text-[var(--color-text)] transition-colors"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+              GitHub
+            </a>
+          </div>
+        </footer>
+        </div>
+      </GitHubAuthProvider>
     </LocaleProvider>
   )
 }

--- a/src/components/CheckinCard.tsx
+++ b/src/components/CheckinCard.tsx
@@ -1,0 +1,368 @@
+import { useState } from 'react'
+import {
+  Dumbbell, Droplets, Check, Settings, X, ChevronUp, ChevronDown,
+} from 'lucide-react'
+import type { Checkin, CheckinItem, CheckinDefaults } from '../types/checkin'
+import { useLocale } from '../hooks/useLocale'
+import { useGitHubAuthContext } from '../hooks/useGitHubAuthContext'
+
+const DEFAULTS_KEY = 'checkin_defaults'
+
+function loadDefaults(): CheckinDefaults {
+  try {
+    const s = localStorage.getItem(DEFAULTS_KEY)
+    if (s) return JSON.parse(s) as CheckinDefaults
+  } catch { /* ignore */ }
+  return { pushupsCount: 30, squatsCount: 30 }
+}
+
+function saveDefaults(d: CheckinDefaults) {
+  localStorage.setItem(DEFAULTS_KEY, JSON.stringify(d))
+}
+
+// ── Item config ───────────────────────────────────────────────────────────────
+
+interface ItemConfig {
+  key: CheckinItem
+  zh: string
+  en: string
+  color: string        // inactive text/border tint
+  activeBg: string
+  activeBorder: string
+  hasCount: boolean
+}
+
+const ITEMS: ItemConfig[] = [
+  {
+    key: 'pushups',
+    zh: '俯卧撑', en: 'Pushups',
+    color: 'orange',
+    activeBg: 'bg-orange-500', activeBorder: 'border-orange-500',
+    hasCount: true,
+  },
+  {
+    key: 'squats',
+    zh: '深蹲', en: 'Squats',
+    color: 'blue',
+    activeBg: 'bg-blue-500', activeBorder: 'border-blue-500',
+    hasCount: true,
+  },
+  {
+    key: 'coldShower',
+    zh: '冷水澡', en: 'Cold Shower',
+    color: 'cyan',
+    activeBg: 'bg-cyan-500', activeBorder: 'border-cyan-500',
+    hasCount: false,
+  },
+]
+
+function ItemIcon({ itemKey, className }: { itemKey: CheckinItem; className?: string }) {
+  if (itemKey === 'pushups') return <Dumbbell className={className} />
+  if (itemKey === 'squats') return <Dumbbell className={className} style={{ transform: 'rotate(90deg)' }} />
+  return <Droplets className={className} />
+}
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="currentColor" viewBox="0 0 24 24">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  )
+}
+
+// ── Settings drawer ───────────────────────────────────────────────────────────
+
+function SettingsDrawer({
+  defaults,
+  onChange,
+  onClose,
+}: {
+  defaults: CheckinDefaults
+  onChange: (d: CheckinDefaults) => void
+  onClose: () => void
+}) {
+  const { locale } = useLocale()
+  const [vals, setVals] = useState(defaults)
+
+  const update = (key: keyof CheckinDefaults, delta: number) => {
+    setVals((prev) => {
+      const next = { ...prev, [key]: Math.max(1, (prev[key] ?? 1) + delta) }
+      onChange(next)
+      return next
+    })
+  }
+
+  const handleInput = (key: keyof CheckinDefaults, value: string) => {
+    const n = parseInt(value)
+    if (!isNaN(n) && n > 0) {
+      const next = { ...vals, [key]: n }
+      setVals(next)
+      onChange(next)
+    }
+  }
+
+  const rows: { key: keyof CheckinDefaults; zh: string; en: string }[] = [
+    { key: 'pushupsCount', zh: '俯卧撑默认数量', en: 'Default Pushups Reps' },
+    { key: 'squatsCount', zh: '深蹲默认数量', en: 'Default Squats Reps' },
+  ]
+
+  return (
+    <div className="mb-5 p-4 rounded-xl bg-[var(--color-bg)] border border-[var(--color-border)]">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-semibold text-[var(--color-text)]">
+          {locale === 'zh' ? '打卡默认设置' : 'Default Reps Settings'}
+        </span>
+        <button onClick={onClose} className="text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="space-y-3">
+        {rows.map((row) => (
+          <div key={row.key} className="flex items-center justify-between">
+            <span className="text-sm text-[var(--color-muted)]">
+              {locale === 'zh' ? row.zh : row.en}
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => update(row.key, -5)}
+                className="w-7 h-7 flex items-center justify-center rounded-lg border border-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)] transition-colors"
+              >
+                <ChevronDown className="w-3.5 h-3.5" />
+              </button>
+              <input
+                type="number"
+                value={vals[row.key]}
+                onChange={(e) => handleInput(row.key, e.target.value)}
+                className="w-14 text-center px-1 py-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+              />
+              <button
+                onClick={() => update(row.key, 5)}
+                className="w-7 h-7 flex items-center justify-center rounded-lg border border-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)] transition-colors"
+              >
+                <ChevronUp className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-[var(--color-muted)] mt-3">
+        {locale === 'zh' ? '打卡时将自动使用以上默认数量，设置保存在本地。' : 'These defaults are used when checking in. Saved locally.'}
+      </p>
+    </div>
+  )
+}
+
+// ── PAT input ─────────────────────────────────────────────────────────────────
+
+function PATInput({ onCancel }: { onCancel: () => void }) {
+  const { locale } = useLocale()
+  const { loading, submitPAT } = useGitHubAuthContext()
+  const [val, setVal] = useState('')
+
+  const handleSubmit = async () => {
+    await submitPAT(val)
+    setVal('')
+  }
+
+  return (
+    <div className="mb-5 p-4 rounded-xl bg-[var(--color-bg)] border border-[var(--color-border)] space-y-3">
+      <div>
+        <p className="text-sm font-medium text-[var(--color-text)] mb-1">
+          {locale === 'zh' ? '输入 GitHub Personal Access Token' : 'Enter GitHub Personal Access Token'}
+        </p>
+        <p className="text-xs text-[var(--color-muted)]">
+          {locale === 'zh'
+            ? '前往 Fine-grained tokens，创建对本 repo 有 Contents 读写权限的 token。'
+            : 'Go to Fine-grained tokens, create a token with Contents read/write on this repo.'}
+        </p>
+        <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener noreferrer"
+          className="text-xs text-[var(--color-accent)] underline mt-1 inline-block">
+          github.com/settings/tokens?type=beta ↗
+        </a>
+      </div>
+      <input
+        type="password"
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && void handleSubmit()}
+        placeholder="github_pat_..."
+        className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] text-sm text-[var(--color-text)] placeholder-[var(--color-muted)] outline-none focus:border-[var(--color-accent)] transition-colors font-mono"
+      />
+      <div className="flex gap-2">
+        <button onClick={() => void handleSubmit()} disabled={!val.trim() || loading}
+          className="flex-1 py-2 rounded-lg bg-[var(--color-accent)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity">
+          {loading ? (locale === 'zh' ? '验证中...' : 'Verifying...') : (locale === 'zh' ? '确认' : 'Confirm')}
+        </button>
+        <button onClick={onCancel}
+          className="px-4 py-2 rounded-lg border border-[var(--color-border)] text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">
+          {locale === 'zh' ? '取消' : 'Cancel'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Main card ─────────────────────────────────────────────────────────────────
+
+interface CheckinCardProps {
+  todayCheckin: Checkin | null
+  saving: boolean
+  onSave: (patch: Partial<Checkin>) => void
+}
+
+export function CheckinCard({ todayCheckin, saving, onSave }: CheckinCardProps) {
+  const { locale } = useLocale()
+  const { token, showPATInput, setShowPATInput } = useGitHubAuthContext()
+  const [showSettings, setShowSettings] = useState(false)
+  const [defaults, setDefaults] = useState<CheckinDefaults>(loadDefaults)
+
+  const handleDefaultsChange = (d: CheckinDefaults) => {
+    setDefaults(d)
+    saveDefaults(d)
+  }
+
+  const today = new Date().toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', {
+    year: 'numeric', month: 'long', day: 'numeric', weekday: 'long',
+  })
+
+  const handleClick = (item: ItemConfig) => {
+    if (!token) return
+    const done = todayCheckin?.[item.key] ?? false
+    if (done) {
+      // toggle off — clear all fields for this item
+      const patch: Partial<Checkin> = { [item.key]: false }
+      if (item.key === 'pushups') { patch.pushupsCount = undefined; patch.pushupsAt = undefined }
+      if (item.key === 'squats')  { patch.squatsCount  = undefined; patch.squatsAt  = undefined }
+      if (item.key === 'coldShower') patch.coldShowerAt = undefined
+      onSave(patch)
+    } else {
+      // check in with defaults + current timestamp
+      const now = new Date().toISOString().slice(0, 19) // "YYYY-MM-DDTHH:mm:ss"
+      const patch: Partial<Checkin> = { [item.key]: true }
+      if (item.key === 'pushups')    { patch.pushupsCount = defaults.pushupsCount; patch.pushupsAt = now }
+      if (item.key === 'squats')     { patch.squatsCount  = defaults.squatsCount;  patch.squatsAt  = now }
+      if (item.key === 'coldShower') { patch.coldShowerAt = now }
+      onSave(patch)
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div>
+          <h2 className="text-lg font-bold text-[var(--color-text)]">
+            {locale === 'zh' ? '今日打卡' : "Today's Check-in"}
+          </h2>
+          <p className="text-xs text-[var(--color-muted)] mt-0.5">{today}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {token && (
+            <button
+              onClick={() => setShowSettings((s) => !s)}
+              className={`w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[var(--color-border)] transition-colors ${showSettings ? 'text-[var(--color-accent)]' : 'text-[var(--color-muted)]'}`}
+              title={locale === 'zh' ? '默认设置' : 'Settings'}
+            >
+              <Settings className="w-4 h-4" />
+            </button>
+          )}
+          {!token && (
+            <button
+              onClick={() => setShowPATInput(true)}
+              className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg bg-[var(--color-accent)] text-white hover:opacity-90 transition-opacity"
+            >
+              <GitHubIcon className="w-4 h-4" />
+              {locale === 'zh' ? 'GitHub 登录' : 'Login with GitHub'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showPATInput && (
+        <PATInput onCancel={() => setShowPATInput(false)} />
+      )}
+
+      {showSettings && token && (
+        <SettingsDrawer
+          defaults={defaults}
+          onChange={handleDefaultsChange}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+
+      {/* Checkin buttons */}
+      <div className="grid grid-cols-3 gap-3">
+        {ITEMS.map((item) => {
+          const done = todayCheckin?.[item.key] ?? false
+          const countVal = item.key === 'pushups'
+            ? todayCheckin?.pushupsCount
+            : item.key === 'squats'
+            ? todayCheckin?.squatsCount
+            : undefined
+          const defaultCount = item.key === 'pushups'
+            ? defaults.pushupsCount
+            : item.key === 'squats'
+            ? defaults.squatsCount
+            : undefined
+          const atVal = item.key === 'pushups'
+            ? todayCheckin?.pushupsAt
+            : item.key === 'squats'
+            ? todayCheckin?.squatsAt
+            : todayCheckin?.coldShowerAt
+          const timeStr = atVal ? atVal.slice(11, 16) : null // "HH:mm"
+
+          return (
+            <button
+              key={item.key}
+              onClick={() => handleClick(item)}
+              disabled={!token || saving}
+              className={`
+                relative flex flex-col items-center justify-center gap-2.5 py-6 px-3 rounded-xl border-2 font-medium transition-all select-none
+                ${done
+                  ? `${item.activeBg} ${item.activeBorder} text-white shadow-lg`
+                  : `bg-transparent border-${item.color}-200 dark:border-${item.color}-900 text-${item.color}-500 hover:border-${item.color}-400 hover:bg-${item.color}-50 dark:hover:bg-${item.color}-950/30`}
+                ${!token ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer active:scale-95'}
+                ${saving ? 'opacity-60' : ''}
+              `}
+            >
+              {done && (
+                <span className="absolute top-2.5 right-2.5 opacity-80">
+                  <Check className="w-3.5 h-3.5" />
+                </span>
+              )}
+              <ItemIcon itemKey={item.key} className="w-7 h-7" />
+              <span className="text-sm font-semibold leading-none">
+                {locale === 'zh' ? item.zh : item.en}
+              </span>
+              {/* count line */}
+              <span className={`text-[11px] leading-none ${done ? 'text-white/70' : `text-${item.color}-400`}`}>
+                {item.hasCount
+                  ? done && countVal != null
+                    ? `${countVal} ${locale === 'zh' ? '个' : 'reps'}`
+                    : `${defaultCount} ${locale === 'zh' ? '个' : 'reps'}`
+                  : done
+                  ? (locale === 'zh' ? '已完成' : 'Done')
+                  : (locale === 'zh' ? '点击打卡' : 'Tap to log')}
+              </span>
+              {/* time line */}
+              {done && timeStr && (
+                <span className="text-[10px] leading-none text-white/50">{timeStr}</span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {!token && !showPATInput && (
+        <p className="text-center text-xs text-[var(--color-muted)] mt-4">
+          {locale === 'zh' ? '登录后才能打卡' : 'Login to start checking in'}
+        </p>
+      )}
+      {saving && (
+        <p className="text-center text-xs text-[var(--color-muted)] mt-3 animate-pulse">
+          {locale === 'zh' ? '保存中...' : 'Saving...'}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/CheckinHeatmap.tsx
+++ b/src/components/CheckinHeatmap.tsx
@@ -1,0 +1,298 @@
+import { useState, useMemo } from 'react'
+import { Dumbbell, Droplets } from 'lucide-react'
+import type { Checkin } from '../types/checkin'
+import { useLocale } from '../hooks/useLocale'
+
+const MONTH_LABELS_ZH = ['1月','2月','3月','4月','5月','6月','7月','8月','9月','10月','11月','12月']
+const MONTH_LABELS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+const DAY_LABELS_ZH = ['一','二','三','四','五','六','日']
+const DAY_LABELS_EN = ['M','T','W','T','F','S','S']
+
+interface HeatmapTrack {
+  key: 'pushups' | 'squats' | 'coldShower'
+  zh: string
+  en: string
+  colors: [string, string, string, string]  // level 1–4
+  emptyColor: { light: string; dark: string }
+}
+
+const TRACKS: HeatmapTrack[] = [
+  {
+    key: 'pushups',
+    zh: '俯卧撑', en: 'Pushups',
+    colors: ['#fed7aa','#fb923c','#f97316','#c2410c'],
+    emptyColor: { light: '#fff7ed', dark: '#1c1008' },
+  },
+  {
+    key: 'squats',
+    zh: '深蹲', en: 'Squats',
+    colors: ['#bfdbfe','#60a5fa','#3b82f6','#1d4ed8'],
+    emptyColor: { light: '#eff6ff', dark: '#080f1c' },
+  },
+  {
+    key: 'coldShower',
+    zh: '冷水澡', en: 'Cold Shower',
+    colors: ['#a5f3fc','#22d3ee','#06b6d4','#0e7490'],
+    emptyColor: { light: '#ecfeff', dark: '#021014' },
+  },
+]
+
+function TrackIcon({ trackKey, className }: { trackKey: HeatmapTrack['key']; className?: string }) {
+  if (trackKey === 'pushups') return <Dumbbell className={className} />
+  if (trackKey === 'squats') return <Dumbbell className={className} style={{ transform: 'rotate(90deg)' }} />
+  return <Droplets className={className} />
+}
+
+type GridCell = { date: string; value: number } | null
+
+interface YearGridResult {
+  grid: GridCell[][]
+  monthPositions: { month: number; weekIndex: number }[]
+  totalDays: number
+  totalReps: number
+}
+
+function buildGrid(year: number, checkins: Checkin[], track: HeatmapTrack): YearGridResult {
+  const jan1 = new Date(year, 0, 1)
+  const startDow = (jan1.getDay() + 6) % 7
+  const daysInYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 366 : 365
+
+  const valueMap = new Map<string, number>()
+  let totalDays = 0, totalReps = 0
+
+  for (const c of checkins) {
+    if (new Date(c.date).getFullYear() !== year) continue
+    if (!c[track.key]) continue
+    totalDays++
+    let val = 1
+    if (track.key === 'pushups' && c.pushupsCount) { val = c.pushupsCount; totalReps += val }
+    else if (track.key === 'squats' && c.squatsCount) { val = c.squatsCount; totalReps += val }
+    valueMap.set(c.date, val)
+  }
+
+  // max for scaling
+  let maxVal = 0
+  valueMap.forEach((v) => { if (v > maxVal) maxVal = v })
+
+  const numWeeks = Math.ceil((startDow + daysInYear) / 7)
+  const grid: GridCell[][] = []
+
+  for (let w = 0; w < numWeeks; w++) {
+    const week: GridCell[] = []
+    for (let d = 0; d < 7; d++) {
+      const dayIndex = w * 7 + d - startDow
+      if (dayIndex < 0 || dayIndex >= daysInYear) { week.push(null); continue }
+      const date = new Date(year, 0, dayIndex + 1).toLocaleDateString('sv-SE')
+      const v = valueMap.get(date) ?? 0
+      week.push({ date, value: v })
+    }
+    grid.push(week)
+  }
+
+  // month positions
+  const monthPositions: { month: number; weekIndex: number }[] = []
+  for (let m = 0; m < 12; m++) {
+    const firstDay = new Date(year, m, 1)
+    const dayIndex = Math.floor((firstDay.getTime() - jan1.getTime()) / 86400000)
+    const weekIndex = Math.floor((startDow + dayIndex) / 7)
+    monthPositions.push({ month: m, weekIndex })
+  }
+
+  return { grid, monthPositions, totalDays, totalReps }
+}
+
+function getColor(value: number, maxVal: number, track: HeatmapTrack, dark: boolean): string {
+  if (value === 0) return dark ? track.emptyColor.dark : track.emptyColor.light
+  if (maxVal === 0) return track.colors[0]
+  const ratio = value / maxVal
+  const level = ratio < 0.25 ? 0 : ratio < 0.5 ? 1 : ratio < 0.75 ? 2 : 3
+  return track.colors[level]
+}
+
+// ── Single track heatmap ──────────────────────────────────────────────────────
+
+function TrackHeatmap({
+  track,
+  checkins,
+  selectedYear,
+  allYears,
+  onYearChange,
+  dark,
+}: {
+  track: HeatmapTrack
+  checkins: Checkin[]
+  selectedYear: number
+  allYears: number[]
+  onYearChange: (y: number) => void
+  dark: boolean
+}) {
+  const { locale } = useLocale()
+  const monthLabels = locale === 'zh' ? MONTH_LABELS_ZH : MONTH_LABELS_EN
+  const dayLabels = locale === 'zh' ? DAY_LABELS_ZH : DAY_LABELS_EN
+
+  const { grid, monthPositions, totalDays, totalReps } = useMemo(
+    () => buildGrid(selectedYear, checkins, track),
+    [selectedYear, checkins, track]
+  )
+
+  // compute max for this year/track
+  const maxVal = useMemo(() => {
+    let m = 0
+    for (const c of checkins) {
+      if (new Date(c.date).getFullYear() !== selectedYear) continue
+      if (!c[track.key]) continue
+      let v = 1
+      if (track.key === 'pushups' && c.pushupsCount) v = c.pushupsCount
+      if (track.key === 'squats' && c.squatsCount) v = c.squatsCount
+      if (v > m) m = v
+    }
+    return m
+  }, [selectedYear, checkins, track])
+
+  const [tooltip, setTooltip] = useState<{ date: string; value: number; x: number; y: number } | null>(null)
+
+  return (
+    <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg flex items-center justify-center" style={{ backgroundColor: track.colors[2] }}>
+            <TrackIcon trackKey={track.key} className="w-4 h-4 text-white" />
+          </div>
+          <div>
+            <span className="text-sm font-semibold text-[var(--color-text)]">
+              {locale === 'zh' ? track.zh : track.en}
+            </span>
+            <span className="ml-2 text-xs text-[var(--color-muted)]">
+              {totalDays} {locale === 'zh' ? '天' : 'd'}
+              {(track.key === 'pushups' || track.key === 'squats') && totalReps > 0 && (
+                <> · {totalReps} {locale === 'zh' ? '个' : 'reps'}</>
+              )}
+            </span>
+          </div>
+        </div>
+        {/* Year tabs */}
+        <div className="flex items-center gap-1">
+          {allYears.map((y) => (
+            <button
+              key={y}
+              onClick={() => onYearChange(y)}
+              className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
+                y === selectedYear
+                  ? 'text-white'
+                  : 'text-[var(--color-muted)] hover:text-[var(--color-text)]'
+              }`}
+              style={y === selectedYear ? { backgroundColor: track.colors[2] } : {}}
+            >
+              {y}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="overflow-x-auto">
+        <div className="inline-flex gap-1 min-w-max">
+          {/* Day labels */}
+          <div className="flex flex-col gap-[3px] pt-5">
+            {dayLabels.map((d, i) => (
+              <div key={i} className={`w-3 h-3 flex items-center justify-center text-[8px] text-[var(--color-muted)] ${i % 2 === 0 ? 'opacity-0' : ''}`}>
+                {d}
+              </div>
+            ))}
+          </div>
+          <div className="relative">
+            {/* Month labels */}
+            <div className="relative h-5 mb-1">
+              {monthPositions.map(({ month, weekIndex }) => (
+                <span key={month} className="absolute text-[10px] text-[var(--color-muted)]"
+                  style={{ left: weekIndex * 15 }}>
+                  {monthLabels[month]}
+                </span>
+              ))}
+            </div>
+            {/* Cells */}
+            <div className="flex gap-[3px]" onMouseLeave={() => setTooltip(null)}>
+              {grid.map((week, wi) => (
+                <div key={wi} className="flex flex-col gap-[3px]">
+                  {week.map((day, di) => (
+                    <div
+                      key={di}
+                      className="w-3 h-3 rounded-sm cursor-default transition-opacity"
+                      style={{
+                        backgroundColor: day ? getColor(day.value, maxVal, track, dark) : 'transparent',
+                        opacity: day === null ? 0 : 1,
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!day) return
+                        const rect = (e.target as HTMLElement).getBoundingClientRect()
+                        setTooltip({ date: day.date, value: day.value, x: rect.left, y: rect.top })
+                      }}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div className="fixed z-50 pointer-events-none bg-[var(--color-text)] text-[var(--color-bg)] text-xs px-2 py-1 rounded shadow"
+          style={{ left: tooltip.x + 14, top: tooltip.y - 10 }}>
+          {tooltip.date}
+          {tooltip.value > 0
+            ? `: ${tooltip.value}${(track.key !== 'coldShower') ? (locale === 'zh' ? ' 个' : ' reps') : ''}`
+            : `: ${locale === 'zh' ? '未打卡' : 'no log'}`}
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="flex items-center gap-1.5 mt-3">
+        <span className="text-[10px] text-[var(--color-muted)]">{locale === 'zh' ? '少' : 'Less'}</span>
+        <div className="w-3 h-3 rounded-sm" style={{ backgroundColor: dark ? track.emptyColor.dark : track.emptyColor.light, border: `1px solid ${track.colors[0]}33` }} />
+        {track.colors.map((c) => (
+          <div key={c} className="w-3 h-3 rounded-sm" style={{ backgroundColor: c }} />
+        ))}
+        <span className="text-[10px] text-[var(--color-muted)]">{locale === 'zh' ? '多' : 'More'}</span>
+      </div>
+    </div>
+  )
+}
+
+// ── Exported component ────────────────────────────────────────────────────────
+
+export function CheckinHeatmap({ checkins }: { checkins: Checkin[] }) {
+  const dark = document.documentElement.classList.contains('dark')
+
+  const allYears = useMemo(() => {
+    const s = new Set<number>()
+    for (const c of checkins) s.add(new Date(c.date).getFullYear())
+    s.add(new Date().getFullYear())
+    return [...s].sort((a, b) => b - a)
+  }, [checkins])
+
+  const currentYear = new Date().getFullYear()
+  const [years, setYears] = useState<Record<string, number>>({
+    pushups: currentYear,
+    squats: currentYear,
+    coldShower: currentYear,
+  })
+
+  return (
+    <div className="space-y-4">
+      {TRACKS.map((track) => (
+        <TrackHeatmap
+          key={track.key}
+          track={track}
+          checkins={checkins}
+          selectedYear={years[track.key] ?? currentYear}
+          allYears={allYears}
+          onYearChange={(y) => setYears((prev) => ({ ...prev, [track.key]: y }))}
+          dark={dark}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/CheckinLog.tsx
+++ b/src/components/CheckinLog.tsx
@@ -1,0 +1,250 @@
+import { useState, useMemo } from 'react'
+import { Dumbbell, Droplets, ChevronLeft, ChevronRight, Clock } from 'lucide-react'
+import type { Checkin } from '../types/checkin'
+import { useLocale } from '../hooks/useLocale'
+
+const PAGE_SIZE = 20
+
+interface LogEntry {
+  date: string        // YYYY-MM-DD
+  item: 'pushups' | 'squats' | 'coldShower'
+  at: string          // ISO timestamp
+  count?: number
+}
+
+const ITEM_META = {
+  pushups: {
+    zh: '俯卧撑', en: 'Pushups',
+    color: '#f97316',
+    bg: 'bg-orange-500/10',
+    border: 'border-orange-500/20',
+    text: 'text-orange-500',
+    Icon: ({ className }: { className?: string }) => <Dumbbell className={className} />,
+  },
+  squats: {
+    zh: '深蹲', en: 'Squats',
+    color: '#3b82f6',
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/20',
+    text: 'text-blue-500',
+    Icon: ({ className }: { className?: string }) => <Dumbbell className={className} style={{ transform: 'rotate(90deg)' }} />,
+  },
+  coldShower: {
+    zh: '冷水澡', en: 'Cold Shower',
+    color: '#06b6d4',
+    bg: 'bg-cyan-500/10',
+    border: 'border-cyan-500/20',
+    text: 'text-cyan-500',
+    Icon: ({ className }: { className?: string }) => <Droplets className={className} />,
+  },
+} as const
+
+function formatAt(iso: string, locale: string): { date: string; time: string; weekday: string } {
+  const d = new Date(iso)
+  const date = d.toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  const time = d.toLocaleTimeString(locale === 'zh' ? 'zh-CN' : 'en-US', { hour: '2-digit', minute: '2-digit', hour12: locale !== 'zh' })
+  const weekday = d.toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', { weekday: 'short' })
+  return { date, time, weekday }
+}
+
+type FilterItem = 'all' | 'pushups' | 'squats' | 'coldShower'
+
+export function CheckinLog({ checkins }: { checkins: Checkin[] }) {
+  const { locale } = useLocale()
+  const [filter, setFilter] = useState<FilterItem>('all')
+  const [page, setPage] = useState(0)
+
+  // Flatten all checkins into individual log entries sorted by time desc
+  const allEntries = useMemo<LogEntry[]>(() => {
+    const entries: LogEntry[] = []
+    for (const c of checkins) {
+      if (c.pushups && c.pushupsAt) {
+        entries.push({ date: c.date, item: 'pushups', at: c.pushupsAt, count: c.pushupsCount })
+      }
+      if (c.squats && c.squatsAt) {
+        entries.push({ date: c.date, item: 'squats', at: c.squatsAt, count: c.squatsCount })
+      }
+      if (c.coldShower && c.coldShowerAt) {
+        entries.push({ date: c.date, item: 'coldShower', at: c.coldShowerAt })
+      }
+      // Fallback: checkin without timestamp — use date only
+      if (c.pushups && !c.pushupsAt) {
+        entries.push({ date: c.date, item: 'pushups', at: c.date + 'T00:00:00', count: c.pushupsCount })
+      }
+      if (c.squats && !c.squatsAt) {
+        entries.push({ date: c.date, item: 'squats', at: c.date + 'T00:00:00', count: c.squatsCount })
+      }
+      if (c.coldShower && !c.coldShowerAt) {
+        entries.push({ date: c.date, item: 'coldShower', at: c.date + 'T00:00:00' })
+      }
+    }
+    return entries.sort((a, b) => b.at.localeCompare(a.at))
+  }, [checkins])
+
+  const filtered = useMemo(
+    () => filter === 'all' ? allEntries : allEntries.filter((e) => e.item === filter),
+    [allEntries, filter]
+  )
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE)
+  const pageData = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  const handleFilter = (f: FilterItem) => { setFilter(f); setPage(0) }
+
+  // Group page entries by date for section dividers
+  const grouped = useMemo(() => {
+    const groups: { date: string; entries: LogEntry[] }[] = []
+    for (const entry of pageData) {
+      const last = groups[groups.length - 1]
+      if (last && last.date === entry.date) {
+        last.entries.push(entry)
+      } else {
+        groups.push({ date: entry.date, entries: [entry] })
+      }
+    }
+    return groups
+  }, [pageData])
+
+  const hasTimestamps = allEntries.some((e) => !e.at.endsWith('T00:00:00'))
+
+  return (
+    <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-bold text-[var(--color-text)]">
+          {locale === 'zh' ? '打卡记录' : 'Checkin Log'}
+        </h3>
+        <span className="text-sm text-[var(--color-muted)]">
+          {locale === 'zh' ? `共 ${filtered.length} 条` : `${filtered.length} entries`}
+        </span>
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+        {(['all', 'pushups', 'squats', 'coldShower'] as FilterItem[]).map((f) => {
+          const meta = f !== 'all' ? ITEM_META[f] : null
+          const isActive = filter === f
+          return (
+            <button
+              key={f}
+              onClick={() => handleFilter(f)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                isActive
+                  ? 'text-white'
+                  : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-text)]'
+              }`}
+              style={isActive && meta ? { backgroundColor: meta.color } : isActive ? { backgroundColor: 'var(--color-accent)' } : {}}
+            >
+              {meta && <meta.Icon className="w-3 h-3" />}
+              {f === 'all'
+                ? (locale === 'zh' ? '全部' : 'All')
+                : locale === 'zh' ? meta!.zh : meta!.en}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Empty state */}
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-[var(--color-muted)] text-sm">
+          {locale === 'zh' ? '暂无记录' : 'No records yet'}
+        </div>
+      )}
+
+      {/* Log entries grouped by date */}
+      <div className="space-y-4">
+        {grouped.map(({ date, entries }) => {
+          const d = new Date(date)
+          const dateLabel = d.toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', {
+            month: 'long', day: 'numeric', weekday: 'long',
+          })
+          return (
+            <div key={date}>
+              {/* Date divider */}
+              <div className="flex items-center gap-3 mb-2">
+                <span className="text-xs font-semibold text-[var(--color-muted)] uppercase tracking-wider whitespace-nowrap">
+                  {dateLabel}
+                </span>
+                <div className="flex-1 h-px bg-[var(--color-border)]" />
+              </div>
+              {/* Entries for this date */}
+              <div className="space-y-2">
+                {entries.map((entry, idx) => {
+                  const meta = ITEM_META[entry.item]
+                  const hasTime = !entry.at.endsWith('T00:00:00')
+                  const { time } = formatAt(entry.at, locale)
+                  return (
+                    <div
+                      key={`${entry.item}-${idx}`}
+                      className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${meta.bg} ${meta.border}`}
+                    >
+                      {/* Icon */}
+                      <div className={`shrink-0 w-8 h-8 rounded-lg flex items-center justify-center`}
+                        style={{ backgroundColor: meta.color + '22' }}>
+                        <meta.Icon className={`w-4 h-4 ${meta.text}`} />
+                      </div>
+
+                      {/* Label */}
+                      <div className="flex-1 min-w-0">
+                        <span className={`text-sm font-semibold ${meta.text}`}>
+                          {locale === 'zh' ? meta.zh : meta.en}
+                        </span>
+                        {entry.count != null && (
+                          <span className="ml-2 text-xs text-[var(--color-muted)]">
+                            {entry.count} {locale === 'zh' ? '个' : 'reps'}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Time */}
+                      <div className="shrink-0 flex items-center gap-1 text-xs text-[var(--color-muted)]">
+                        {hasTime && <Clock className="w-3 h-3" />}
+                        <span className="font-mono">
+                          {hasTime ? time : (locale === 'zh' ? '时间未记录' : 'no time')}
+                        </span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-5 pt-4 border-t border-[var(--color-border)]">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="flex items-center gap-1 text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] disabled:opacity-30 transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            {locale === 'zh' ? '上一页' : 'Prev'}
+          </button>
+          <span className="text-sm text-[var(--color-muted)]">
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+            className="flex items-center gap-1 text-sm text-[var(--color-muted)] hover:text-[var(--color-text)] disabled:opacity-30 transition-colors"
+          >
+            {locale === 'zh' ? '下一页' : 'Next'}
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Notice for old entries without timestamps */}
+      {!hasTimestamps && checkins.length > 0 && (
+        <p className="text-xs text-[var(--color-muted)] mt-3 text-center">
+          {locale === 'zh'
+            ? '历史记录未含时间信息，新打卡将自动记录时间'
+            : 'Historical records have no timestamps. New check-ins will record time automatically.'}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/CheckinPage.tsx
+++ b/src/components/CheckinPage.tsx
@@ -1,0 +1,42 @@
+import { useGitHubAuthContext } from '../hooks/useGitHubAuthContext'
+import { useCheckins } from '../hooks/useCheckins'
+import { CheckinCard } from './CheckinCard'
+import { CheckinStats } from './CheckinStats'
+import { CheckinHeatmap } from './CheckinHeatmap'
+import { CheckinLog } from './CheckinLog'
+import { useLocale } from '../hooks/useLocale'
+import type { Checkin } from '../types/checkin'
+
+export function CheckinPage() {
+  const { locale } = useLocale()
+  const { token } = useGitHubAuthContext()
+  const { checkins, todayCheckin, saveCheckin, loading, saving, error } = useCheckins(token)
+
+  return (
+    <main className="max-w-[900px] mx-auto px-6 py-6 space-y-6">
+      {error && (
+        <div className="rounded-xl bg-red-500/10 border border-red-500/30 px-4 py-3 text-sm text-red-500">
+          {locale === 'zh' ? '错误：' : 'Error: '}{error}
+        </div>
+      )}
+
+      <CheckinCard
+        todayCheckin={todayCheckin}
+        saving={saving}
+        onSave={(patch: Partial<Checkin>) => { void saveCheckin(patch) }}
+      />
+
+      {loading ? (
+        <div className="text-center text-sm text-[var(--color-muted)] py-8 animate-pulse">
+          {locale === 'zh' ? '加载打卡记录...' : 'Loading checkin records...'}
+        </div>
+      ) : (
+        <>
+          <CheckinStats checkins={checkins} />
+          <CheckinHeatmap checkins={checkins} />
+          <CheckinLog checkins={checkins} />
+        </>
+      )}
+    </main>
+  )
+}

--- a/src/components/CheckinStats.tsx
+++ b/src/components/CheckinStats.tsx
@@ -1,0 +1,102 @@
+import { Dumbbell, Droplets, Flame, CalendarCheck } from 'lucide-react'
+import type { Checkin } from '../types/checkin'
+import { useLocale } from '../hooks/useLocale'
+
+function computeStreak(checkins: Checkin[]): number {
+  const sorted = [...checkins].sort((a, b) => b.date.localeCompare(a.date))
+  const today = new Date().toLocaleDateString('sv-SE')
+  let streak = 0
+  let expected = today
+  for (const c of sorted) {
+    if (c.date !== expected) break
+    if (c.pushups || c.squats || c.coldShower) {
+      streak++
+      const d = new Date(expected)
+      d.setDate(d.getDate() - 1)
+      expected = d.toLocaleDateString('sv-SE')
+    } else break
+  }
+  return streak
+}
+
+export function CheckinStats({ checkins }: { checkins: Checkin[] }) {
+  const { locale } = useLocale()
+  const streak = computeStreak(checkins)
+  const totalDays = checkins.filter((c) => c.pushups || c.squats || c.coldShower).length
+  const pushupDays = checkins.filter((c) => c.pushups).length
+  const pushupReps = checkins.reduce((s, c) => s + (c.pushupsCount ?? 0), 0)
+  const squatDays = checkins.filter((c) => c.squats).length
+  const squatReps = checkins.reduce((s, c) => s + (c.squatsCount ?? 0), 0)
+  const coldShowerDays = checkins.filter((c) => c.coldShower).length
+
+  const stats = [
+    {
+      label: locale === 'zh' ? '连续打卡' : 'Streak',
+      primary: streak,
+      unit: locale === 'zh' ? '天' : 'd',
+      sub: null,
+      Icon: Flame,
+      iconColor: 'text-[var(--color-accent)]',
+      valueColor: 'text-[var(--color-accent)]',
+    },
+    {
+      label: locale === 'zh' ? '累计天数' : 'Total Days',
+      primary: totalDays,
+      unit: locale === 'zh' ? '天' : 'd',
+      sub: null,
+      Icon: CalendarCheck,
+      iconColor: 'text-[var(--color-muted)]',
+      valueColor: 'text-[var(--color-text)]',
+    },
+    {
+      label: locale === 'zh' ? '俯卧撑' : 'Pushups',
+      primary: pushupDays,
+      unit: locale === 'zh' ? '天' : 'd',
+      sub: pushupReps > 0 ? `${pushupReps} ${locale === 'zh' ? '个' : 'reps'}` : null,
+      Icon: Dumbbell,
+      iconColor: 'text-orange-500',
+      valueColor: 'text-orange-500',
+    },
+    {
+      label: locale === 'zh' ? '深蹲' : 'Squats',
+      primary: squatDays,
+      unit: locale === 'zh' ? '天' : 'd',
+      sub: squatReps > 0 ? `${squatReps} ${locale === 'zh' ? '个' : 'reps'}` : null,
+      Icon: Dumbbell,
+      iconColor: 'text-blue-500',
+      valueColor: 'text-blue-500',
+    },
+    {
+      label: locale === 'zh' ? '冷水澡' : 'Cold Shower',
+      primary: coldShowerDays,
+      unit: locale === 'zh' ? '天' : 'd',
+      sub: null,
+      Icon: Droplets,
+      iconColor: 'text-cyan-500',
+      valueColor: 'text-cyan-500',
+    },
+  ]
+
+  return (
+    <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-card)] p-5">
+      <h3 className="text-sm font-semibold text-[var(--color-muted)] uppercase tracking-wider mb-4">
+        {locale === 'zh' ? '打卡统计' : 'Checkin Stats'}
+      </h3>
+      <div className="grid grid-cols-5 gap-2">
+        {stats.map((s) => (
+          <div key={s.label} className="flex flex-col items-center gap-1.5 py-2">
+            <s.Icon className={`w-4 h-4 ${s.iconColor}`} />
+            <div className={`text-xl font-bold leading-none ${s.valueColor}`}>
+              {s.primary}
+              <span className="text-xs font-normal ml-0.5">{s.unit}</span>
+            </div>
+            {s.sub && (
+              <div className="text-[10px] text-[var(--color-muted)] leading-none">{s.sub}</div>
+            )}
+            <div className="text-[10px] text-[var(--color-muted)] text-center leading-tight">{s.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,11 @@
+import { useState, useRef, useEffect } from 'react'
+import { LogOut } from 'lucide-react'
 import type { SportFilter, Activity } from '../types'
 import { WORKOUT_TYPES } from '../types'
 import { useLocale } from '../hooks/useLocale'
+import { useGitHubAuthContext } from '../hooks/useGitHubAuthContext'
 
-type Page = 'home' | 'tracks'
+type Page = 'home' | 'tracks' | 'checkin'
 
 interface HeaderProps {
   filter: SportFilter
@@ -12,6 +15,109 @@ interface HeaderProps {
   activities: Activity[]
   page: Page
   onNavigate: (p: Page) => void
+}
+
+function GitHubAuthDropdown() {
+  const { locale } = useLocale()
+  const { user, loading, showPATInput, setShowPATInput, submitPAT, logout } = useGitHubAuthContext()
+  const [open, setOpen] = useState(false)
+  const [patValue, setPatValue] = useState('')
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+        setShowPATInput(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [setShowPATInput])
+
+  const handleSubmit = async () => {
+    await submitPAT(patValue)
+    setPatValue('')
+  }
+
+  if (user) {
+    return (
+      <div ref={ref} className="relative">
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="flex items-center gap-2 rounded-full hover:ring-2 hover:ring-[var(--color-accent)]/40 transition-all"
+        >
+          <img src={user.avatar_url} alt={user.login} className="w-7 h-7 rounded-full" />
+        </button>
+        {open && (
+          <div className="absolute right-0 top-10 w-48 rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] shadow-lg py-1 z-50">
+            <div className="px-3 py-2 border-b border-[var(--color-border)]">
+              <p className="text-xs font-semibold text-[var(--color-text)]">{user.name ?? user.login}</p>
+              <p className="text-xs text-[var(--color-muted)]">@{user.login}</p>
+            </div>
+            <button
+              onClick={() => { logout(); setOpen(false) }}
+              className="w-full flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)] transition-colors"
+            >
+              <LogOut className="w-3.5 h-3.5" />
+              {locale === 'zh' ? '退出登录' : 'Logout'}
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => { setOpen((o) => !o); setShowPATInput(true) }}
+        disabled={loading}
+        className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-[var(--color-accent)] text-white hover:opacity-90 disabled:opacity-60 transition-opacity"
+        title={locale === 'zh' ? '登录 GitHub' : 'Login with GitHub'}
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+        </svg>
+        {loading ? '...' : (locale === 'zh' ? '登录' : 'Login')}
+      </button>
+
+      {(open || showPATInput) && !user && (
+        <div className="absolute right-0 top-10 w-72 rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] shadow-lg p-4 z-50 space-y-3">
+          <p className="text-xs font-semibold text-[var(--color-text)]">
+            {locale === 'zh' ? 'GitHub Personal Access Token' : 'GitHub Personal Access Token'}
+          </p>
+          <p className="text-xs text-[var(--color-muted)]">
+            {locale === 'zh'
+              ? '需要对本 repo 有 Contents 读写权限'
+              : 'Needs Contents read/write access on this repo'}
+          </p>
+          <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener noreferrer"
+            className="text-xs text-[var(--color-accent)] underline inline-block">
+            github.com/settings/tokens?type=beta ↗
+          </a>
+          <input
+            type="password"
+            value={patValue}
+            onChange={(e) => setPatValue(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && void handleSubmit()}
+            placeholder="github_pat_..."
+            className="w-full px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] text-xs text-[var(--color-text)] placeholder-[var(--color-muted)] outline-none focus:border-[var(--color-accent)] transition-colors font-mono"
+          />
+          <div className="flex gap-2">
+            <button onClick={() => void handleSubmit()} disabled={!patValue.trim() || loading}
+              className="flex-1 py-1.5 rounded-lg bg-[var(--color-accent)] text-white text-xs font-medium hover:opacity-90 disabled:opacity-50 transition-opacity">
+              {loading ? (locale === 'zh' ? '验证中...' : 'Verifying...') : (locale === 'zh' ? '确认' : 'Confirm')}
+            </button>
+            <button onClick={() => { setOpen(false); setShowPATInput(false) }}
+              className="px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-xs text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors">
+              {locale === 'zh' ? '取消' : 'Cancel'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function Header({ filter, setFilter, dark, toggleTheme, activities, page, onNavigate }: HeaderProps) {
@@ -36,6 +142,7 @@ export function Header({ filter, setFilter, dark, toggleTheme, activities, page,
   const navItems: { label: string; page: Page }[] = [
     { label: t('home'), page: 'home' },
     { label: t('tracks'), page: 'tracks' },
+    { label: t('checkin'), page: 'checkin' },
   ]
 
   return (
@@ -53,7 +160,7 @@ export function Header({ filter, setFilter, dark, toggleTheme, activities, page,
           {tabs.map((tab) => (
             <button
               key={tab.value}
-              onClick={() => { setFilter(tab.value); onNavigate('home') }}
+              onClick={() => { setFilter(tab.value); if (page === 'checkin') onNavigate('home') }}
               className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
                 filter === tab.value && page === 'home'
                   ? 'bg-[var(--color-accent)] text-white'
@@ -66,7 +173,8 @@ export function Header({ filter, setFilter, dark, toggleTheme, activities, page,
         </div>
 
         {/* Right nav */}
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-4">
+          {/* Page nav */}
           {navItems.map((item) => (
             <span
               key={item.label}
@@ -80,6 +188,8 @@ export function Header({ filter, setFilter, dark, toggleTheme, activities, page,
               {item.label}
             </span>
           ))}
+
+          {/* Theme toggle */}
           <button
             onClick={toggleTheme}
             className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[var(--color-card)] transition-colors"
@@ -94,24 +204,17 @@ export function Header({ filter, setFilter, dark, toggleTheme, activities, page,
               </svg>
             )}
           </button>
+
+          {/* Locale toggle */}
           <button
             onClick={() => setLocale(locale === 'zh' ? 'en' : 'zh')}
             className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[var(--color-card)] transition-colors text-[var(--color-muted)] hover:text-[var(--color-text)] text-xs font-bold"
-            title={locale === 'zh' ? 'Switch to English' : '切换中文'}
           >
             {locale === 'zh' ? 'EN' : '中'}
           </button>
-          <a
-            href="https://github.com/zhaohongxuan/workouts"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[var(--color-card)] transition-colors text-[var(--color-muted)] hover:text-[var(--color-text)]"
-            title="GitHub"
-          >
-            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-            </svg>
-          </a>
+
+          {/* GitHub Auth */}
+          <GitHubAuthDropdown />
         </div>
       </div>
     </header>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -76,12 +76,21 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const formatHours = (secs: number) => `${(secs / 3600).toFixed(1)}h`
 
   const formatSyncTime = (isoStr: string) => {
-    const d = new Date(isoStr)
+    const diffMs = Date.now() - new Date(isoStr).getTime()
+    const mins = Math.floor(diffMs / 60000)
+    const hours = Math.floor(mins / 60)
+    const days = Math.floor(hours / 24)
     if (locale === 'zh') {
-      return `${d.getMonth() + 1}月${d.getDate()}日 ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
+      if (mins < 1) return '刚刚'
+      if (mins < 60) return `${mins} 分钟前`
+      if (hours < 24) return `${hours} 小时前`
+      return `${days} 天前`
+    } else {
+      if (mins < 1) return 'just now'
+      if (mins < 60) return `${mins}m ago`
+      if (hours < 24) return `${hours}h ago`
+      return `${days}d ago`
     }
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
   }
 
   const latest = activities.length > 0

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -25,6 +25,7 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const [runStatus, setRunStatus] = useState<RunStatus>('idle')
   const [runUrl, setRunUrl] = useState<string | null>(null)
   const [statusMsg, setStatusMsg] = useState('')
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(() => localStorage.getItem('lastSyncedAt'))
 
   const filteredActivities = filter === 'all' ? activities : activities.filter(a => a.type === filter)
 
@@ -54,6 +55,15 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
 
   const formatHours = (secs: number) => `${(secs / 3600).toFixed(1)}h`
 
+  const formatSyncTime = (isoStr: string) => {
+    const d = new Date(isoStr)
+    if (locale === 'zh') {
+      return `${d.getMonth() + 1}月${d.getDate()}日 ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
+    }
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' +
+      d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+  }
+
   const latest = activities.length > 0
     ? [...activities].sort((a, b) => new Date(b.start_date_local).getTime() - new Date(a.start_date_local).getTime())[0]
     : null
@@ -79,6 +89,11 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
       if (data.status === 'completed') {
         setRunStatus(data.conclusion === 'success' ? 'success' : 'failure')
         setStatusMsg(data.conclusion ?? '')
+        if (data.conclusion === 'success') {
+          const now = new Date().toISOString()
+          setLastSyncedAt(now)
+          localStorage.setItem('lastSyncedAt', now)
+        }
       } else {
         setRunStatus(data.status as RunStatus)
         setTimeout(() => void pollRun(runId, attempt + 1), 5000)
@@ -199,6 +214,12 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
           <div className="flex items-center justify-between mb-1">
             <p className="text-xs text-[var(--color-muted)]">{locale === 'zh' ? '最近活动' : 'Latest Activity'}</p>
             <div className="flex items-center gap-2">
+              {lastSyncedAt && runStatus === 'idle' && (
+                <span className="text-xs text-[var(--color-muted)] flex items-center gap-1">
+                  <Clock className="w-3 h-3" />
+                  {formatSyncTime(lastSyncedAt)}
+                </span>
+              )}
               <StatusBadge />
               {token && (
                 <button

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { RefreshCw, CheckCircle, XCircle, Clock, Loader, Route } from 'lucide-react'
 import type { Activity, SportFilter } from '../types'
 import { useLocale } from '../hooks/useLocale'
@@ -26,6 +26,26 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const [runUrl, setRunUrl] = useState<string | null>(null)
   const [statusMsg, setStatusMsg] = useState('')
   const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(() => localStorage.getItem('lastSyncedAt'))
+
+  // Fetch last successful workflow run time on mount (when token available)
+  useEffect(() => {
+    if (!token) return
+    void (async () => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=1`,
+          { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' } }
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as { workflow_runs: Array<{ updated_at: string }> }
+        const run = data.workflow_runs[0]
+        if (run) {
+          setLastSyncedAt(run.updated_at)
+          localStorage.setItem('lastSyncedAt', run.updated_at)
+        }
+      } catch { /* ignore */ }
+    })()
+  }, [token])
 
   const filteredActivities = filter === 'all' ? activities : activities.filter(a => a.type === filter)
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,7 +1,17 @@
+import { useState, useCallback } from 'react'
+import { RefreshCw, CheckCircle, XCircle, Clock, Loader, Route } from 'lucide-react'
 import type { Activity, SportFilter } from '../types'
 import { useLocale } from '../hooks/useLocale'
+import { useGitHubAuthContext } from '../hooks/useGitHubAuthContext'
 import { formatDistance, parseMovingTime, extractProvince } from '../hooks/useActivities'
-import avatar from '../assets/avatar.jpg'
+import rawConfig from '@config'
+
+const config = rawConfig as { repoOwner?: string; repoName?: string }
+const REPO_OWNER = config.repoOwner ?? 'zhaohongxuan'
+const REPO_NAME  = config.repoName  ?? 'workouts'
+const WORKFLOW_FILE = 'run_data_sync.yml'
+
+type RunStatus = 'idle' | 'triggering' | 'queued' | 'in_progress' | 'success' | 'failure' | 'error'
 
 interface ProfileCardProps {
   activities: Activity[]
@@ -10,8 +20,12 @@ interface ProfileCardProps {
 
 export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const { t, locale } = useLocale()
+  const { token } = useGitHubAuthContext()
 
-  // Filter activities by sport type for distance/count/time
+  const [runStatus, setRunStatus] = useState<RunStatus>('idle')
+  const [runUrl, setRunUrl] = useState<string | null>(null)
+  const [statusMsg, setStatusMsg] = useState('')
+
   const filteredActivities = filter === 'all' ? activities : activities.filter(a => a.type === filter)
 
   const totalDistance = filteredActivities.reduce((s, a) => s + a.distance, 0)
@@ -21,26 +35,19 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const allDates = activities.map((a) => new Date(a.start_date_local).getFullYear())
   const yearsActive = allDates.length > 0 ? (Math.max(...allDates) - Math.min(...allDates) + 1) : 0
 
-  // Countries and provinces — use shared extractProvince for consistency with ChinaMap
   const countries = new Set<string>()
   const provinces = new Set<string>()
   for (const a of activities) {
     const loc = a.location_country
     if (!loc || loc === 'None') continue
-    // Detect country
     if (loc.startsWith('{')) {
       try {
         const d = JSON.parse(loc.replace(/'/g, '"').replace(/None/g, 'null'))
         if (d.country) countries.add(d.country)
       } catch { /* ignore */ }
-    } else if (loc.includes('泰国')) {
-      countries.add('泰国')
-    } else if (loc.includes('日本')) {
-      countries.add('日本')
-    } else {
-      countries.add('中国')
-    }
-    // Province — use shared logic (China-only)
+    } else if (loc.includes('泰国')) { countries.add('泰国')
+    } else if (loc.includes('日本')) { countries.add('日本')
+    } else { countries.add('中国') }
     const p = extractProvince(loc)
     if (p) provinces.add(p)
   }
@@ -48,81 +55,166 @@ export function ProfileCard({ activities, filter = 'all' }: ProfileCardProps) {
   const formatHours = (secs: number) => `${(secs / 3600).toFixed(1)}h`
 
   const latest = activities.length > 0
-    ? [...activities].sort((a, b) =>
-        new Date(b.start_date_local).getTime() - new Date(a.start_date_local).getTime()
-      )[0]
+    ? [...activities].sort((a, b) => new Date(b.start_date_local).getTime() - new Date(a.start_date_local).getTime())[0]
     : null
 
   const formatDate = (dateStr: string) => {
     const d = new Date(dateStr)
-    if (locale === 'zh') {
-      return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
-    }
+    if (locale === 'zh') return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  }
+
+  // ── Workflow trigger & poll ───────────────────────────────────────────────
+
+  const pollRun = useCallback(async (runId: number, attempt = 0) => {
+    if (attempt > 30) { setRunStatus('error'); setStatusMsg('Timeout'); return }
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runs/${runId}`,
+        { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' } }
+      )
+      if (!res.ok) { setRunStatus('error'); return }
+      const data = (await res.json()) as { status: string; conclusion: string | null; html_url: string }
+      setRunUrl(data.html_url)
+      if (data.status === 'completed') {
+        setRunStatus(data.conclusion === 'success' ? 'success' : 'failure')
+        setStatusMsg(data.conclusion ?? '')
+      } else {
+        setRunStatus(data.status as RunStatus)
+        setTimeout(() => void pollRun(runId, attempt + 1), 5000)
+      }
+    } catch { setRunStatus('error') }
+  }, [token])
+
+  const triggerSync = useCallback(async () => {
+    if (!token) return
+    setRunStatus('triggering')
+    setRunUrl(null)
+    setStatusMsg('')
+    try {
+      // Trigger workflow_dispatch
+      const triggerRes = await fetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/workflows/${WORKFLOW_FILE}/dispatches`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ ref: 'master' }),
+        }
+      )
+      if (!triggerRes.ok) {
+        const err = (await triggerRes.json()) as { message?: string }
+        throw new Error(err.message ?? `${triggerRes.status}`)
+      }
+      setRunStatus('queued')
+      // Wait a bit then find the new run
+      await new Promise((r) => setTimeout(r, 4000))
+      const runsRes = await fetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runs?per_page=5&event=workflow_dispatch`,
+        { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' } }
+      )
+      if (!runsRes.ok) throw new Error('Failed to list runs')
+      const runsData = (await runsRes.json()) as { workflow_runs: Array<{ id: number; html_url: string; created_at: string }> }
+      const latest = runsData.workflow_runs[0]
+      if (latest) {
+        setRunUrl(latest.html_url)
+        void pollRun(latest.id)
+      }
+    } catch (e) {
+      setRunStatus('error')
+      setStatusMsg(String(e))
+    }
+  }, [token, pollRun])
+
+  // ── Status badge ─────────────────────────────────────────────────────────
+
+  function StatusBadge() {
+    if (runStatus === 'idle') return null
+    const map: Record<RunStatus, { icon: React.ReactNode; label: string; color: string }> = {
+      idle:        { icon: null, label: '', color: '' },
+      triggering:  { icon: <Loader className="w-3 h-3 animate-spin" />, label: locale === 'zh' ? '触发中...' : 'Triggering…', color: 'text-[var(--color-muted)]' },
+      queued:      { icon: <Clock className="w-3 h-3" />,              label: locale === 'zh' ? '队列中' : 'Queued',       color: 'text-yellow-500' },
+      in_progress: { icon: <Loader className="w-3 h-3 animate-spin" />, label: locale === 'zh' ? '运行中...' : 'Running…',  color: 'text-blue-500' },
+      success:     { icon: <CheckCircle className="w-3 h-3" />,         label: locale === 'zh' ? '同步成功' : 'Synced',     color: 'text-green-500' },
+      failure:     { icon: <XCircle className="w-3 h-3" />,             label: locale === 'zh' ? '同步失败' : 'Failed',     color: 'text-red-500' },
+      error:       { icon: <XCircle className="w-3 h-3" />,             label: statusMsg || (locale === 'zh' ? '出错了' : 'Error'), color: 'text-red-500' },
+    }
+    const { icon, label, color } = map[runStatus]
+    const content = (
+      <span className={`flex items-center gap-1 text-xs ${color}`}>
+        {icon}{label}
+      </span>
+    )
+    return runUrl ? <a href={runUrl} target="_blank" rel="noopener noreferrer">{content}</a> : content
   }
 
   return (
     <div className="bg-[var(--color-card)] border border-[var(--color-border)] rounded-xl p-5 transition-all duration-300 hover:shadow-lg hover:shadow-[var(--color-accent)]/5 hover:border-[var(--color-accent)]/30 hover:bg-[var(--color-accent)]/5">
-      {/* Avatar top-left + Distance */}
-      <div className="flex items-center gap-4">
-        <div className="w-14 h-14 rounded-full overflow-hidden border-2 border-[var(--color-border)] shrink-0">
-          <img
-            src={avatar}
-            alt="avatar"
-            className="w-full h-full object-cover"
-          />
-        </div>
-        <div className="flex-1 text-center">
-          <p className="text-3xl font-bold font-mono">
-            {formatDistance(totalDistance)}
-            <span className="text-base font-normal text-[var(--color-muted)] ml-1">km</span>
-          </p>
-          <p className="mt-0.5 text-sm text-[var(--color-muted)] flex items-center justify-center gap-1">
+      {/* Distance */}
+      <div className="text-center">
+        <p className="text-3xl font-bold font-mono flex items-center justify-center gap-2">
+          <Route className="w-6 h-6 text-[var(--color-accent)]" />
+          {formatDistance(totalDistance)}
+          <span className="text-base font-normal text-[var(--color-muted)]">km</span>
+        </p>
+        <p className="mt-0.5 text-sm text-[var(--color-muted)] flex items-center justify-center gap-1">
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
             {countries.size} {t('countries')} ·
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" /><path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
             {provinces.size} {t('provinces')}
           </p>
         </div>
-      </div>
 
-      {/* Stats row - Strava style */}
+      {/* Stats row */}
       <div className="grid grid-cols-3 gap-2 mt-4 text-center border-t border-[var(--color-border)] pt-4">
         <div>
           <p className="text-xs text-[var(--color-muted)] flex items-center justify-center gap-1">
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
             {t('activities')}
           </p>
           <p className="text-lg font-bold">{totalCount.toLocaleString()}</p>
         </div>
         <div className="border-x border-[var(--color-border)]">
           <p className="text-xs text-[var(--color-muted)] flex items-center justify-center gap-1">
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
             {t('years')}
           </p>
           <p className="text-lg font-bold">{yearsActive}</p>
         </div>
         <div>
           <p className="text-xs text-[var(--color-muted)] flex items-center justify-center gap-1">
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
             {locale === 'zh' ? '时间' : 'Time'}
           </p>
           <p className="text-lg font-bold">{formatHours(totalSeconds)}</p>
         </div>
       </div>
 
-      {/* Latest Activity */}
+      {/* Latest Activity + Sync */}
       {latest && (
         <div className="mt-4 pt-4 border-t border-[var(--color-border)]">
-          <p className="text-xs text-[var(--color-muted)] mb-1">{locale === 'zh' ? '最近活动' : 'Latest Activity'}</p>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--color-muted)]">{locale === 'zh' ? '最近活动' : 'Latest Activity'}</p>
+            <div className="flex items-center gap-2">
+              <StatusBadge />
+              {token && (
+                <button
+                  onClick={() => void triggerSync()}
+                  disabled={runStatus === 'triggering' || runStatus === 'queued' || runStatus === 'in_progress'}
+                  title={locale === 'zh' ? '触发 Strava 同步' : 'Trigger Strava sync'}
+                  className="flex items-center gap-1 text-xs text-[var(--color-muted)] hover:text-[var(--color-accent)] disabled:opacity-40 transition-colors"
+                >
+                  <RefreshCw className={`w-3.5 h-3.5 ${runStatus === 'in_progress' || runStatus === 'triggering' ? 'animate-spin' : ''}`} />
+                  {locale === 'zh' ? '同步' : 'Sync'}
+                </button>
+              )}
+            </div>
+          </div>
           <p className="text-sm font-medium">
-            {latest.type === 'Run' ? '🏃 ' : '🚴 '}
+            {latest.type === 'Run' ? '🏃 ' : latest.type === 'Ride' ? '🚴 ' : '🏋️ '}
             {latest.name || (latest.type === 'Run' ? 'Run' : 'Ride')}
             <span className="text-[var(--color-muted)] font-normal"> · {formatDistance(latest.distance)} km · {formatDate(latest.start_date_local)}</span>
           </p>

--- a/src/hooks/useCheckins.ts
+++ b/src/hooks/useCheckins.ts
@@ -1,0 +1,117 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { Checkin, CheckinData } from '../types/checkin'
+import rawConfig from '@config'
+
+const config = rawConfig as { repoOwner?: string; repoName?: string }
+const REPO_OWNER = config.repoOwner ?? ''
+const REPO_NAME = config.repoName ?? ''
+const FILE_PATH = 'data/checkins.json'
+
+function todayStr() {
+  return new Date().toLocaleDateString('sv-SE')
+}
+
+async function encodeContent(obj: unknown): Promise<string> {
+  const jsonStr = JSON.stringify(obj, null, 2) + '\n'
+  const bytes = new TextEncoder().encode(jsonStr)
+  return btoa(bytes.reduce((s, b) => s + String.fromCharCode(b), ''))
+}
+
+interface UseCheckinsResult {
+  checkins: Checkin[]
+  todayCheckin: Checkin | null
+  saveCheckin: (patch: Partial<Checkin>) => Promise<void>
+  loading: boolean
+  saving: boolean
+  error: string | null
+}
+
+export function useCheckins(token: string | null): UseCheckinsResult {
+  const [checkins, setCheckins] = useState<Checkin[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fileSha, setFileSha] = useState<string | null>(null)
+
+  const today = todayStr()
+  const todayCheckin = checkins.find((c) => c.date === today) ?? null
+
+  const fetchCheckins = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const headers: Record<string, string> = { Accept: 'application/vnd.github+json' }
+      if (token) headers['Authorization'] = `Bearer ${token}`
+      if (!REPO_OWNER || !REPO_NAME) { setCheckins([]); setLoading(false); return }
+      const res = await fetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${FILE_PATH}`,
+        { headers }
+      )
+      if (!res.ok) {
+        if (res.status === 404) setCheckins([])
+        else setError(`GitHub API error: ${res.status}`)
+        setLoading(false)
+        return
+      }
+      const data = (await res.json()) as { content: string; sha: string }
+      setFileSha(data.sha)
+      const decoded = atob(data.content.replace(/\n/g, ''))
+      const json = JSON.parse(decoded) as CheckinData
+      setCheckins(json.checkins ?? [])
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [token])
+
+  useEffect(() => { void fetchCheckins() }, [fetchCheckins])
+
+  const saveCheckin = useCallback(async (patch: Partial<Checkin>) => {
+    if (!token) return
+    if (!REPO_OWNER || !REPO_NAME) {
+      alert('请先在 config.yml 中配置 repoOwner 和 repoName。')
+      return
+    }
+    const prev = checkins
+    const existing = checkins.find((c) => c.date === today)
+    const base: Checkin = existing ?? { date: today, pushups: false, squats: false, coldShower: false }
+    const merged: Checkin = { ...base, ...patch }
+    const updated = existing
+      ? checkins.map((c) => (c.date === today ? merged : c))
+      : [...checkins, merged].sort((a, b) => a.date.localeCompare(b.date))
+    setCheckins(updated)
+
+    setSaving(true)
+    try {
+      const content = await encodeContent({ checkins: updated })
+      const body: Record<string, string> = { message: `checkin: update ${today}`, content }
+      if (fileSha) body['sha'] = fileSha
+      const res = await fetch(
+        `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${FILE_PATH}`,
+        {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        }
+      )
+      if (!res.ok) {
+        const err = (await res.json()) as { message?: string }
+        throw new Error(err.message ?? `GitHub API error: ${res.status}`)
+      }
+      const result = (await res.json()) as { content: { sha: string } }
+      setFileSha(result.content.sha)
+    } catch (e) {
+      setCheckins(prev)
+      setError(String(e))
+    } finally {
+      setSaving(false)
+    }
+  }, [token, checkins, today, fileSha])
+
+  return { checkins, todayCheckin, saveCheckin, loading, saving, error }
+}

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -1,0 +1,3 @@
+// Re-export from global context for backward compatibility
+export { useGitHubAuthContext as useGitHubAuth } from './useGitHubAuthContext'
+export type { GitHubAuthContextValue as GitHubAuthState } from './useGitHubAuthContext'

--- a/src/hooks/useGitHubAuthContext.tsx
+++ b/src/hooks/useGitHubAuthContext.tsx
@@ -1,0 +1,86 @@
+import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
+import type { GitHubUser } from '../types/checkin'
+
+const STORAGE_TOKEN_KEY = 'checkin_github_token'
+const STORAGE_USER_KEY = 'checkin_github_user'
+
+export interface GitHubAuthContextValue {
+  token: string | null
+  user: GitHubUser | null
+  loading: boolean
+  showPATInput: boolean
+  setShowPATInput: (v: boolean) => void
+  submitPAT: (pat: string) => Promise<void>
+  logout: () => void
+}
+
+const GitHubAuthContext = createContext<GitHubAuthContextValue | null>(null)
+
+export function GitHubAuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem(STORAGE_TOKEN_KEY))
+  const [user, setUser] = useState<GitHubUser | null>(() => {
+    const s = localStorage.getItem(STORAGE_USER_KEY)
+    return s ? (JSON.parse(s) as GitHubUser) : null
+  })
+  const [loading, setLoading] = useState(false)
+  const [showPATInput, setShowPATInput] = useState(false)
+  const didInit = useRef(false)
+
+  const fetchUser = useCallback(async (t: string): Promise<boolean> => {
+    try {
+      const res = await fetch('https://api.github.com/user', {
+        headers: { Authorization: `Bearer ${t}`, Accept: 'application/json' },
+      })
+      if (!res.ok) {
+        localStorage.removeItem(STORAGE_TOKEN_KEY)
+        localStorage.removeItem(STORAGE_USER_KEY)
+        setToken(null); setUser(null)
+        return false
+      }
+      const data = (await res.json()) as GitHubUser
+      localStorage.setItem(STORAGE_USER_KEY, JSON.stringify(data))
+      setUser(data)
+      return true
+    } catch { return false }
+  }, [])
+
+  useEffect(() => {
+    if (!didInit.current && token && !user) {
+      didInit.current = true
+      void fetchUser(token)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const submitPAT = useCallback(async (pat: string) => {
+    const trimmed = pat.trim()
+    if (!trimmed) return
+    setLoading(true)
+    const ok = await fetchUser(trimmed)
+    if (ok) {
+      localStorage.setItem(STORAGE_TOKEN_KEY, trimmed)
+      setToken(trimmed)
+      setShowPATInput(false)
+    } else {
+      alert('Token 无效或权限不足，请检查后重试。\nInvalid token or insufficient permissions.')
+    }
+    setLoading(false)
+  }, [fetchUser])
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(STORAGE_TOKEN_KEY)
+    localStorage.removeItem(STORAGE_USER_KEY)
+    setToken(null); setUser(null); setShowPATInput(false)
+  }, [])
+
+  return (
+    <GitHubAuthContext.Provider value={{ token, user, loading, showPATInput, setShowPATInput, submitPAT, logout }}>
+      {children}
+    </GitHubAuthContext.Provider>
+  )
+}
+
+export function useGitHubAuthContext(): GitHubAuthContextValue {
+  const ctx = useContext(GitHubAuthContext)
+  if (!ctx) throw new Error('useGitHubAuthContext must be used within GitHubAuthProvider')
+  return ctx
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -44,6 +44,7 @@ export const messages: Record<Locale, Record<string, string>> = {
     page: '第',
     pageOf: '页 / 共',
     pages: '页',
+    checkin: '打卡',
   },
   en: {
     totalDistance: 'Total Distance',
@@ -88,5 +89,6 @@ export const messages: Record<Locale, Record<string, string>> = {
     page: 'Page',
     pageOf: 'of',
     pages: '',
+    checkin: 'Habits',
   },
 }

--- a/src/types/checkin.ts
+++ b/src/types/checkin.ts
@@ -1,0 +1,28 @@
+export interface Checkin {
+  date: string              // YYYY-MM-DD
+  pushups: boolean
+  pushupsCount?: number     // reps
+  pushupsAt?: string        // ISO timestamp e.g. "2026-05-18T06:30:00"
+  squats: boolean
+  squatsCount?: number      // reps
+  squatsAt?: string
+  coldShower: boolean
+  coldShowerAt?: string
+}
+
+export interface CheckinData {
+  checkins: Checkin[]
+}
+
+export type CheckinItem = 'pushups' | 'squats' | 'coldShower'
+
+export interface GitHubUser {
+  login: string
+  avatar_url: string
+  name: string | null
+}
+
+export interface CheckinDefaults {
+  pushupsCount: number
+  squatsCount: number
+}


### PR DESCRIPTION
## Summary

- **新增每日打卡模块**（俯卧撑 / 深蹲 / 冷水澡），独立顶部 Tab，数据存储于 `data/checkins.json`，通过 GitHub Contents API 读写，无需后端
- **全局 GitHub PAT 认证**（Context），Header 展示头像/登录入口，所有功能共用同一 token
- **ProfileCard 同步按钮**，一键触发 `run_data_sync.yml` workflow dispatch，实时轮询展示 Action 状态
- UI 调整：移除个人资料头像、里程前加 Route 图标、GitHub 链接移至 footer
- Workflow 精简：移除 Make svg / Set Output steps

## New Files
- `src/components/CheckinCard.tsx` — 今日打卡卡片（默认数量设置、一键打卡、时间戳）
- `src/components/CheckinHeatmap.tsx` — 三个独立热力图（橙/蓝/青色系）
- `src/components/CheckinLog.tsx` — 按日期分组的打卡记录日志
- `src/components/CheckinStats.tsx` — 统计卡片（连续天数、总 reps）
- `src/components/CheckinPage.tsx` — 打卡 Tab 主页面
- `src/hooks/useGitHubAuthContext.tsx` — 全局 GitHub 认证 Context
- `src/hooks/useCheckins.ts` — GitHub Contents API 读写 hook
- `src/types/checkin.ts` — Checkin 类型定义
- `data/checkins.json` — 打卡数据文件
- `docs/ios-shortcuts.md` — iOS 快捷指令方案文档
- `CHANGELOG.md` — 项目变更日志，版本 2.0.0 → 3.0.0

## Test plan
- [ ] `pnpm dev` 启动无报错
- [ ] 顶栏右侧显示 GitHub 登录按钮，登录后显示头像及下拉
- [ ] 打卡 Tab 可正常打卡，刷新后数据持久化（GitHub repo 有新 commit）
- [ ] 三个热力图独立显示，打卡记录日志时间正确
- [ ] ProfileCard 同步按钮触发 Action，状态实时更新
- [ ] `pnpm build` 无 TypeScript 错误